### PR TITLE
SA-2997: Prevent Domain Leave when AzureAD Joined

### DIFF
--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -181,8 +181,8 @@ function show-mtpSelection {
                 <CheckBox Name="cb_forcereboot" Content="Force Reboot" HorizontalAlignment="Left" Margin="10,101,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
                 <CheckBox Name="cb_installjcagent" Content="Install JCAgent" HorizontalAlignment="Left" Margin="123,101,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
                 <CheckBox Name="cb_bindAsAdmin" Content="Bind As Admin" HorizontalAlignment="Left" Margin="253,101,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False" IsEnabled="False"/>
-                <CheckBox Name="cb_leavedomain" Content="Leave Domain" HorizontalAlignment="Left" Margin="10,123,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
-                <CheckBox Name="cb_autobindjcuser" Content="Autobind JC User" HorizontalAlignment="Left" Margin="123,123,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False" ToolTip=""/>
+                <CheckBox Name="cb_leavedomain" ToolTipService.ShowOnDisabled="True" Content="Leave Domain" HorizontalAlignment="Left" Margin="10,123,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
+                <CheckBox Name="cb_autobindjcuser" Content="Autobind JC User" HorizontalAlignment="Left" Margin="123,123,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
                 <Image Name="img_ckey_info" HorizontalAlignment="Left" Height="14" Margin="157,13,0,0" VerticalAlignment="Top" Width="14" Visibility="Hidden" ToolTip="The Connect Key provides you with a means of associating this system with your JumpCloud organization. The Key is used to deploy the agent to this system." />
                 <Image Name="img_ckey_valid" HorizontalAlignment="Left" Height="14" Margin="454,13,0,0" VerticalAlignment="Top" Width="14" Visibility="Hidden" ToolTip="Connect Key must be 40chars &amp; not contain spaces" />
                 <Image Name="img_apikey_info" HorizontalAlignment="Left" Height="14" Margin="157,42,0,0" VerticalAlignment="Top" Width="14" Visibility="Hidden" ToolTip="Click the link for more info on how to obtain the api key. The API key must be from a user with at least 'Manager' or 'Administrator' privileges." RenderTransformOrigin="1.857,-1.066"/>
@@ -535,15 +535,15 @@ $cb_autobindjcuser.Add_Unchecked( {
     })
 
 # Leave Domain checkbox
-$script:LeaveDomain = $false
-$cb_leavedomain.Add_Checked( { $script:LeaveDomain = $true })
-$cb_leavedomain.Add_Unchecked( { $script:LeaveDomain = $false })
-
 # If system is joined to AzureAD, disable Leave Domain checkbox
 if ($AzureADStatus -eq "YES") {
-    $cb_leavedomain.IsEnabled = $false
-    $cb_leavedomain.Add_Unchecked( { $script:LeaveDomain = $false })
     $cb_leavedomain.ToolTip = "Unable to automatically leave domain due to being AzureAD Joined - https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Leaving-AzureAD-Domains"
+    $cb_leavedomain.Add_Unchecked( { $script:LeaveDomain = $false })
+    $cb_leavedomain.IsEnabled = $false
+} else {
+    $script:LeaveDomain = $false
+    $cb_leavedomain.Add_Checked( { $script:LeaveDomain = $true })
+    $cb_leavedomain.Add_Unchecked( { $script:LeaveDomain = $false })
 }
 
 # Force Reboot checkbox

--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -543,8 +543,7 @@ $cb_leavedomain.Add_Unchecked( { $script:LeaveDomain = $false })
 if ($AzureADStatus -eq "YES") {
     $cb_leavedomain.IsEnabled = $false
     $cb_leavedomain.Add_Unchecked( { $script:LeaveDomain = $false })
-    $cb_leavedomain.ToolTip = "Unable to automatically leave domain due to being AzureAD Joined"
-    $cb_leavedomain.ToolTip.Add_PreviewMouseDown( { [System.Diagnostics.Process]::start("https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Leaving-AzureAD-Domains") })
+    $cb_leavedomain.ToolTip = "Unable to automatically leave domain due to being AzureAD Joined - https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Leaving-AzureAD-Domains"
 }
 
 # Force Reboot checkbox

--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -182,7 +182,7 @@ function show-mtpSelection {
                 <CheckBox Name="cb_installjcagent" Content="Install JCAgent" HorizontalAlignment="Left" Margin="123,101,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
                 <CheckBox Name="cb_bindAsAdmin" Content="Bind As Admin" HorizontalAlignment="Left" Margin="253,101,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False" IsEnabled="False"/>
                 <CheckBox Name="cb_leavedomain" Content="Leave Domain" HorizontalAlignment="Left" Margin="10,123,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
-                <CheckBox Name="cb_autobindjcuser" Content="Autobind JC User" HorizontalAlignment="Left" Margin="123,123,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
+                <CheckBox Name="cb_autobindjcuser" Content="Autobind JC User" HorizontalAlignment="Left" Margin="123,123,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False" ToolTip=""/>
                 <Image Name="img_ckey_info" HorizontalAlignment="Left" Height="14" Margin="157,13,0,0" VerticalAlignment="Top" Width="14" Visibility="Hidden" ToolTip="The Connect Key provides you with a means of associating this system with your JumpCloud organization. The Key is used to deploy the agent to this system." />
                 <Image Name="img_ckey_valid" HorizontalAlignment="Left" Height="14" Margin="454,13,0,0" VerticalAlignment="Top" Width="14" Visibility="Hidden" ToolTip="Connect Key must be 40chars &amp; not contain spaces" />
                 <Image Name="img_apikey_info" HorizontalAlignment="Left" Height="14" Margin="157,42,0,0" VerticalAlignment="Top" Width="14" Visibility="Hidden" ToolTip="Click the link for more info on how to obtain the api key. The API key must be from a user with at least 'Manager' or 'Administrator' privileges." RenderTransformOrigin="1.857,-1.066"/>
@@ -538,6 +538,14 @@ $cb_autobindjcuser.Add_Unchecked( {
 $script:LeaveDomain = $false
 $cb_leavedomain.Add_Checked( { $script:LeaveDomain = $true })
 $cb_leavedomain.Add_Unchecked( { $script:LeaveDomain = $false })
+
+# If system is joined to AzureAD, disable Leave Domain checkbox
+if ($AzureADStatus -eq "YES") {
+    $cb_leavedomain.IsEnabled = $false
+    $cb_leavedomain.Add_Unchecked( { $script:LeaveDomain = $false })
+    $cb_leavedomain.ToolTip = "Unable to automatically leave domain due to being AzureAD Joined"
+    $cb_leavedomain.ToolTip.Add_PreviewMouseDown( { [System.Diagnostics.Process]::start("https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Leaving-AzureAD-Domains") })
+}
 
 # Force Reboot checkbox
 $script:ForceReboot = $false


### PR DESCRIPTION
## Issues
* [SA-2997:](https://jumpcloud.atlassian.net/browse/SA-2997:) - Prevent Domain Leave when AzureAD Joined

## What does this solve?
Currently, we are unable to force devices to leave an AzureAD domain via ADMU (https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Leaving-AzureAD-Domains). This simply causes the checkbox to be disabled and will display a ToolTip with further information

## Is there anything particularly tricky?
To allow ToolTips to be visible on disabled controls, the `ToolTipService.ShowOnDisabled="True"` has to be placed in the XML portion of the Form

## How should this be tested?
Run ADMU on an AzureAD joined device, the Leave Domain checkbox will be disabled
Run ADMU on a non-AzureAD joined device, the Leave Domain checkbox will be enabled

## Screenshots
<img width="985" alt="image" src="https://user-images.githubusercontent.com/89030113/205414740-469d2007-ef7d-4340-88ac-569ba7a41507.png">
