### PR TITLE
SA-3527 fix ad status for leave domain

### DIFF
--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -1955,6 +1955,13 @@ Function Start-Migration {
                 New-Item -ItemType Directory -Force -Path $path
             }
             $appxList = @()
+            # Get Azure AD Status
+            $ADStatus = dsregcmd.exe /status
+            foreach ($line in $ADStatus) {
+                if ($line -match "AzureADJoined : ") {
+                    $AzureADStatus = ($line.trimstart('AzureADJoined : '))
+                }
+            }
             if ($AzureADProfile -eq $true -or $netBiosName -match 'AzureAD') {
                 # Find Appx User Apps by Username
                 try {
@@ -2020,12 +2027,6 @@ Function Start-Migration {
             #region Leave Domain or AzureAD
 
             if ($LeaveDomain -eq $true) {
-                # Get Azure AD Status
-                foreach ($line in $AzureADInfo) {
-                    if ($line -match "AzureADJoined : ") {
-                        $AzureADStatus = ($line.trimstart('AzureADJoined : '))
-                    }
-                }
                 if ($AzureADStatus -match 'YES') {
                     # Check if user is not NTAUTHORITY\SYSTEM
                     if (([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).user.Value -match "S-1-5-18")) -eq $false) {


### PR DESCRIPTION
## Issues
* [SA-3527](https://jumpcloud.atlassian.net/browse/SA-3527) - SA-3527-Leave-Domain-AD-Check-Fix

## What does this solve?
Current leave domain AD Status condition does not work since a variable that should contain a status value is not set. 
## Is there anything particularly tricky?

## How should this be tested?
1. Run the ADMU prod with leave domain set to $true
- Run this script after: 
```
$ADStatus = dsregcmd.exe /status
                        foreach ($line in $ADStatus) {
                            if ($line -match "AzureADJoined : ") {
                                $AzureADStatus = ($line.trimstart('AzureADJoined : '))
                            }
                        }
```
- $AzureADStatus  Should be set to 'YES'
2. Run ADMU with the new changes then do same process above, $AzureADStatus  should be set to "NO"

## Screenshots

[SA-3527]: https://jumpcloud.atlassian.net/browse/SA-3527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ