### PR TITLE
Leave Domain Option Fix on Non-AD Bound Device

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -6,6 +6,7 @@ Release Date: February 16, 2024
 
 ```
 * When loading/ unloading a user's registry hive and an error is encounered, the tool will attempt to close any processes owned by that user.
+* Added error mapping function to provide useful information for troubleshooting to admin when an error pops up.
 ```
 
 ## 2.6.2

--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -179,7 +179,7 @@ function show-mtpSelection {
                 <CheckBox Name="cb_forcereboot" Content="Force Reboot" HorizontalAlignment="Left" Margin="10,101,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
                 <CheckBox Name="cb_installjcagent" Content="Install JCAgent" HorizontalAlignment="Left" Margin="123,101,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
                 <CheckBox Name="cb_bindAsAdmin" Content="Bind As Admin" HorizontalAlignment="Left" Margin="253,101,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False" IsEnabled="False"/>
-                <CheckBox Name="cb_leavedomain" ToolTipService.ShowOnDisabled="True" Content="Leave Domain" HorizontalAlignment="Left" Margin="10,123,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
+                <CheckBox Name="cb_leavedomain" ToolTipService.ShowOnDisabled="True" Content="Leave Domain" HorizontalAlignment="Left" Margin="10,123,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False" IsEnabled="false"/>
                 <CheckBox Name="cb_autobindjcuser" Content="Autobind JC User" HorizontalAlignment="Left" Margin="123,123,0,0" VerticalAlignment="Top" FontWeight="Normal" IsChecked="False"/>
                 <Image Name="img_ckey_info" HorizontalAlignment="Left" Height="14" Margin="157,13,0,0" VerticalAlignment="Top" Width="14" Visibility="Hidden" ToolTip="The Connect Key provides you with a means of associating this system with your JumpCloud organization. The Key is used to deploy the agent to this system." />
                 <Image Name="img_ckey_valid" HorizontalAlignment="Left" Height="14" Margin="454,13,0,0" VerticalAlignment="Top" Width="14" Visibility="Hidden" ToolTip="Connect Key must be 40chars &amp; not contain spaces" />
@@ -294,6 +294,9 @@ if ((Get-CimInstance Win32_OperatingSystem).Version -match '10') {
         }
         if ($line -match "TenantName : ") {
             $TenantName = ($line.trimstart('WorkplaceTenantName : '))
+        }
+        if ($line -match "DomainJoined : ") {
+            $AzureDomainStatus = ($line.trimstart('DomainJoined : '))
         }
     }
 } else {
@@ -534,6 +537,12 @@ $cb_autobindjcuser.Add_Unchecked( {
 
 
 # Leave Domain checkbox
+if (($AzureADStatus -eq 'Yes') -or ($AzureDomainStatus -eq 'Yes')) {
+    $script:cb_leavedomain.IsEnabled = $true
+} else {
+    Write-ToLog "Device is not AzureAD Joined or Domain Joined. Leave Domain Checkbox Disabled."
+    $script:cb_leavedomain.IsEnabled = $false
+}
 $script:LeaveDomain = $false
 $cb_leavedomain.Add_Checked( { $script:LeaveDomain = $true })
 $cb_leavedomain.Add_Unchecked( { $script:LeaveDomain = $false })

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -2756,7 +2756,7 @@ Function Start-Migration {
                             try {
                                 Invoke-AsSystem { dsregcmd.exe /leave }
                             } catch {
-                                Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
+                                Write-ToLog -Message:('Unable to leave domain') -Level:('Warn')
                             }
                             # Get Azure AD Status
                             $ADStatus = dsregcmd.exe /status

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -2776,7 +2776,7 @@ Function Start-Migration {
                                 Write-toLog -message "Left Azure AD domain successfully`nDevice Domain State`nAzureADJoined : $AzureADStatus`nEnterpriseJoined : $AzureEnterpriseStatus`nDomainJoined : $AzureDomainStatus" -Level Verbose
 
                             } else {
-                                Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
+                                Write-ToLog -Message:('Unable to leave domain') -Level:('Warn')
                             }
 
                         } else {

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -2675,6 +2675,9 @@ Function Start-Migration {
                 if ($line -match "AzureADJoined : ") {
                     $AzureADStatus = ($line.trimstart('AzureADJoined : '))
                 }
+                if ($line -match "DomainJoined : ") {
+                    $AzureDomainStatus = ($line.trimstart('DomainJoined : '))
+                }
             }
             Write-Progress -Activity "Migrating User to JumpCloud" -Status "Checking AD status" -PercentComplete ($progressCounter++ / $progressCount * 100)
 
@@ -2744,57 +2747,64 @@ Function Start-Migration {
 
             #region Leave Domain or AzureAD
 
-            if ($LeaveDomain -eq $true) {
-                if ($AzureADStatus -match 'YES') {
-                    # Check if user is not NTAUTHORITY\SYSTEM
-                    if (([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).user.Value -match "S-1-5-18")) -eq $false) {
-                        Write-ToLog -Message:('User not NTAuthority\SYSTEM. Invoking as System to leave AzureAD') -Level Verbose
-                        try {
-                            Invoke-AsSystem { dsregcmd.exe /leave }
-                        } catch {
-                            Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
-                        }
-                        # Get Azure AD Status
-                        $ADStatus = dsregcmd.exe /status
-                        foreach ($line in $ADStatus) {
-                            if ($line -match "AzureADJoined : ") {
-                                $AzureADStatus = ($line.trimstart('AzureADJoined : '))
+            if (($AzureADStatus -eq 'YES') -or ($AzureDomainStatus -eq 'YES')){
+                if ($LeaveDomain -eq $true) {
+                    if ($AzureADStatus -match 'YES') {
+                        # Check if user is not NTAUTHORITY\SYSTEM
+                        if (([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).user.Value -match "S-1-5-18")) -eq $false) {
+                            Write-ToLog -Message:('User not NTAuthority\SYSTEM. Invoking as System to leave AzureAD') -Level Verbose
+                            try {
+                                Invoke-AsSystem { dsregcmd.exe /leave }
+                            } catch {
+                                Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
                             }
-                            if ($line -match "EnterpriseJoined : ") {
-                                $AzureEnterpriseStatus = ($line.trimstart('EnterpriseJoined : '))
+                            # Get Azure AD Status
+                            $ADStatus = dsregcmd.exe /status
+                            foreach ($line in $ADStatus) {
+                                if ($line -match "AzureADJoined : ") {
+                                    $AzureADStatus = ($line.trimstart('AzureADJoined : '))
+                                }
+                                if ($line -match "EnterpriseJoined : ") {
+                                    $AzureEnterpriseStatus = ($line.trimstart('EnterpriseJoined : '))
+                                }
+                                if ($line -match "DomainJoined : ") {
+                                    $AzureDomainStatus = ($line.trimstart('DomainJoined : '))
+                                }
                             }
-                            if ($line -match "DomainJoined : ") {
-                                $AzureDomainStatus = ($line.trimstart('DomainJoined : '))
+                            # Check Azure AD status after running dsregcmd.exe /leave as NTAUTHORITY\SYSTEM
+                            if ($AzureADStatus -match 'NO') {
+                                Write-toLog -message "Left Azure AD domain successfully`nDevice Domain State`nAzureADJoined : $AzureADStatus`nEnterpriseJoined : $AzureEnterpriseStatus`nDomainJoined : $AzureDomainStatus" -Level Verbose
+
+                            } else {
+                                Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
                             }
-                        }
-                        # Check Azure AD status after running dsregcmd.exe /leave as NTAUTHORITY\SYSTEM
-                        if ($AzureADStatus -match 'NO') {
-                            Write-toLog -message "Left Azure AD domain successfully`nDevice Domain State`nAzureADJoined : $AzureADStatus`nEnterpriseJoined : $AzureEnterpriseStatus`nDomainJoined : $AzureDomainStatus" -Level Verbose
 
                         } else {
-                            Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
+                            try {
+                                Write-ToLog -Message:('Leaving AzureAD Domain with dsregcmd.exe ')
+                                dsregcmd.exe /leave
+                            } catch {
+                                Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
+                                # $admuTracker.leaveDomain.fail = $true
+                            }
                         }
-
                     } else {
-                        try {
-                            Write-ToLog -Message:('Leaving AzureAD Domain with dsregcmd.exe ')
-                            dsregcmd.exe /leave
-                        } catch {
+                        Try {
+                            Write-ToLog -Message:('Leaving Domain')
+                            $WmiComputerSystem.UnJoinDomainOrWorkGroup($null, $null, 0)
+                        } Catch {
                             Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
                             # $admuTracker.leaveDomain.fail = $true
                         }
                     }
-                } else {
-                    Try {
-                        Write-ToLog -Message:('Leaving Domain')
-                        $WmiComputerSystem.UnJoinDomainOrWorkGroup($null, $null, 0)
-                    } Catch {
-                        Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
-                        # $admuTracker.leaveDomain.fail = $true
-                    }
+                    $admuTracker.leaveDomain.pass = $true
                 }
-                $admuTracker.leaveDomain.pass = $true
+            } else {
+                if ($LeaveDomain -eq $true) {
+                    Write-ToLog -Message:('Device is not AzureAD or Domain Joined, no action taken') -Level:('Info')
+                }
             }
+
 
             # re-enable scheduled tasks if they were disabled
             if ($ScheduledTasks) {

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -2793,7 +2793,7 @@ Function Start-Migration {
                             Write-ToLog -Message:('Leaving Domain')
                             $WmiComputerSystem.UnJoinDomainOrWorkGroup($null, $null, 0)
                         } Catch {
-                            Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
+                            Write-ToLog -Message:('Unable to leave domain') -Level:('Warn')
                             # $admuTracker.leaveDomain.fail = $true
                         }
                     }

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -2784,7 +2784,7 @@ Function Start-Migration {
                                 Write-ToLog -Message:('Leaving AzureAD Domain with dsregcmd.exe ')
                                 dsregcmd.exe /leave
                             } catch {
-                                Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
+                                Write-ToLog -Message:('Unable to leave domain') -Level:('Warn')
                                 # $admuTracker.leaveDomain.fail = $true
                             }
                         }


### PR DESCRIPTION
## Issues
* [CUT-3871](https://jumpcloud.atlassian.net/browse/CUT-3871) - CUT-3871-NonAD-Bound-System-No-Leave-Domain-Option

## What does this solve?
Fixes issue with leave domain GUI checkbox and -leaveDomain parameter in terminal that still tries to leave domain even when device is not AD bound.
## Is there anything particularly tricky?
n/a
## How should this be tested?
GUI
1. Run the GUI on an AD bound device and non-ad bound device
2. Validate that the GUI checkbox is enabled on AD bound device and disabled on non-ad bound device
Terminal
1. Run Start-Migration AD bound device and non-ad bound device
2. Set `-leaveDomain $true` on a non-ad device, this should still run the migration but will not try to leave the domain. 
![image](https://github.com/TheJumpCloud/jumpcloud-ADMU/assets/97972790/3e4eeba1-1675-477a-9118-bdbbf9550ace)
3. Set `-leaveDomain $true` on a domain joined device. Validate that the device leave the domain.


[CUT-3871]: https://jumpcloud.atlassian.net/browse/CUT-3871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ