### PR TITLE
Sign with new STM account

### DIFF
--- a/.github/workflows/admu-release.yml
+++ b/.github/workflows/admu-release.yml
@@ -156,7 +156,6 @@ jobs:
           curl -X GET https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
           msiexec /i smtools-windows-x64.msi /quiet /qn
           smksp_registrar.exe list > nul 2>&1
-          smctl.exe healthcheck > nul 2>&1
           smctl.exe keypair ls > nul 2>&1
           C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user > nul 2>&1
           smksp_cert_sync.exe > nul 2>&1

--- a/.github/workflows/admu-release.yml
+++ b/.github/workflows/admu-release.yml
@@ -140,22 +140,23 @@ jobs:
         shell: bash
         run: |
           # Create Client Cert File
-          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+          echo "${{ secrets.SM_V2_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
           # Create Environment Variables
           echo "::set-output name=version::${GITHUB_REF#refs/tags/v}"
           echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
-          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
+          echo "SM_API_KEY=${{ secrets.SM_V2_API_KEY }}" >> "$GITHUB_ENV"
           echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_V2_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
           echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
           echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
       - name: Setup SSM KSP for Code Signing
         shell: cmd
         run: |
-          curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
+          curl -X GET https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
           msiexec /i smtools-windows-x64.msi /quiet /qn
           smksp_registrar.exe list > nul 2>&1
+          smctl.exe healthcheck > nul 2>&1
           smctl.exe keypair ls > nul 2>&1
           C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user > nul 2>&1
           smksp_cert_sync.exe > nul 2>&1

--- a/Deploy/Sign.ps1
+++ b/Deploy/Sign.ps1
@@ -43,7 +43,7 @@ foreach ($file in $filesToSign) {
         # new
         & $signpath sign `
             /d "$filename" `
-            /sha1 $rootSubjectName `
+            /r $rootSubjectName `
             /tr $($tsaServers[$tsaIndex]) `
             /td SHA256 `
             /fd SHA256 `

--- a/Deploy/Sign.ps1
+++ b/Deploy/Sign.ps1
@@ -23,7 +23,8 @@ $filesToSign = @(
 )
 
 Write-Output "Signing with Production Cert"
-$codeSigningCertHash = $env:SM_CODE_SIGNING_CERT_SHA1_HASH
+# only sign release builds
+$rootSubjectName = "DigiCert Trusted Root G4"
 
 foreach ($file in $filesToSign) {
     If (Test-Path -Path ($file)) {
@@ -42,7 +43,7 @@ foreach ($file in $filesToSign) {
         # new
         & $signpath sign `
             /d "$filename" `
-            /sha1 $codeSigningCertHash `
+            /sha1 $rootSubjectName `
             /tr $($tsaServers[$tsaIndex]) `
             /td SHA256 `
             /fd SHA256 `


### PR DESCRIPTION
## Issues
* [AR-492](https://jumpcloud.atlassian.net/browse/AR-492) - Sign with new STM account

## What does this solve?

Switches Windows signing over to using the new DigiCert STM account.

## Is there anything particularly tricky?

Signing with the production cert won't be tested until this is merged.

## How should this be tested?

## Screenshots

[AR-492]: https://jumpcloud.atlassian.net/browse/AR-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ