### PR TITLE
hostname and JCUsername validation check

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -11,6 +11,7 @@ Release Date: February 16, 2024
 ```
 * When loading/ unloading a user's registry hive and an error is encounered, the tool will attempt to close any processes owned by that user.
 * Added error mapping function to provide useful information for troubleshooting to admin when an error pops up.
+* Added a validation to check if jumpcloud username and local username are the same
 ```
 
 ## 2.6.2

--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -388,7 +388,7 @@ $lbNetBios.Content = $NetBiosName
 #AzureADInformation
 $lbAzureAD_Joined.Content = $AzureADStatus
 $lbTenantName.Content = $TenantName
-
+$hostname = hostname
 Function Test-Button([object]$tbJumpCloudUserName, [object]$tbJumpCloudConnectKey, [object]$tbTempPassword, [object]$lvProfileList, [object]$tbJumpCloudAPIKey) {
     If (![System.String]::IsNullOrEmpty($lvProfileList.SelectedItem.UserName)) {
         If (!(Test-IsNotEmpty $tbJumpCloudUserName.Text) -and (Test-HasNoSpace $tbJumpCloudUserName.Text) -and (($($tbJumpCloudUserName.Text).length) -le 20) `
@@ -553,9 +553,10 @@ $script:ForceReboot = $false
 $cb_forcereboot.Add_Checked( { $script:ForceReboot = $true })
 $cb_forcereboot.Add_Unchecked( { $script:ForceReboot = $false })
 
+$hostname = hostname
 $tbJumpCloudUserName.add_TextChanged( {
         Test-Button -tbJumpCloudUserName:($tbJumpCloudUserName) -tbJumpCloudConnectKey:($tbJumpCloudConnectKey) -tbTempPassword:($tbTempPassword) -lvProfileList:($lvProfileList) -tbJumpCloudAPIKey:($tbJumpCloudAPIKey)
-        If ((Test-IsNotEmpty $tbJumpCloudUserName.Text) -or (!(Test-HasNoSpace $tbJumpCloudUserName.Text)) -or (Test-Localusername $tbJumpCloudUserName.Text) -or (($tbJumpCloudUserName.Text).Length -gt 20)) {
+        If ((Test-IsNotEmpty $tbJumpCloudUserName.Text) -or (!(Test-HasNoSpace $tbJumpCloudUserName.Text)) -or (Test-Localusername $tbJumpCloudUserName.Text) -or (($tbJumpCloudUserName.Text).Length -gt 20) -or $tbJumpCloudUserName.Text -eq $hostname) {
             $tbJumpCloudUserName.Background = "#FFC6CBCF"
             $tbJumpCloudUserName.BorderBrush = "#FFF90000"
             $img_localaccount_valid.Source = DecodeBase64Image -ImageBase64 $ErrorBase64
@@ -567,6 +568,11 @@ $tbJumpCloudUserName.add_TextChanged( {
             $img_localaccount_valid.Source = DecodeBase64Image -ImageBase64 $ActiveBase64
             $img_localaccount_valid.ToolTip = $null
         }
+        if($tbJumpCloudUserName.Text -eq $hostname){
+            Write-ToLog "JumpCloud Username can not be the same as the hostname"
+            $script:bMigrateProfile.IsEnabled = $false
+            $img_localaccount_valid.ToolTip = "JumpCloud Username can not be the same as the hostname. Please change the username."
+            }
     })
 
 $tbJumpCloudConnectKey.Add_PasswordChanged( {
@@ -675,8 +681,6 @@ $bMigrateProfile.Add_Click( {
                 Write-ToLog "$($tbJumpCloudUserName.Text) not found in the JumpCloud console"
                 return
             }
-
-
             if ( -not [string]::isnullorempty($JCSystemUsername) ) {
                 # Regex to get the username from the domain\username string and compare it to JCSystemUsername
                 #Get all the local users

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -1898,6 +1898,12 @@ Function Start-Migration {
             break
         }
 
+        # Get the value of selectedusername after / if it exists "domain\username" get the username
+        $selectedUsernameVal = $SelectedUserName.Split('\')[-1]
+        if($JumpCloudUserName -eq $selectedUsernameVal) {
+            Throw [System.Management.Automation.ValidationMetadataException] "JumpCloudUserName and SelectedUserName cannot be the same. Exiting..."
+            break
+        }
         # Conditional ParameterSet logic
         If ($PSCmdlet.ParameterSetName -eq "form") {
             $SelectedUserName = $inputObject.SelectedUserName

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -1898,10 +1898,9 @@ Function Start-Migration {
             break
         }
 
-        # Get the value of selectedusername after / if it exists "domain\username" get the username
-        $selectedUsernameVal = $SelectedUserName.Split('\')[-1]
-        if($JumpCloudUserName -eq $selectedUsernameVal) {
-            Throw [System.Management.Automation.ValidationMetadataException] "JumpCloudUserName and SelectedUserName cannot be the same. Exiting..."
+        $hostname = hostname # Get computer hostname
+        if($JumpCloudUserName -eq $hostname) {
+            Throw [System.Management.Automation.ValidationMetadataException] "JumpCloudUserName and Hostname cannot be the same. Exiting..."
             break
         }
         # Conditional ParameterSet logic

--- a/jumpcloud-ADMU/Powershell/Tests/Migration.Tests.ps1
+++ b/jumpcloud-ADMU/Powershell/Tests/Migration.Tests.ps1
@@ -363,7 +363,7 @@ Describe 'Migration Test Scenarios' {
             $user1 = "ADMU_" + -join ((65..90) + (97..122) | Get-Random -Count 5 | ForEach-Object { [char]$_ })
             $user2 = "ADMU_" + -join ((65..90) + (97..122) | Get-Random -Count 5 | ForEach-Object { [char]$_ })
             InitUser -UserName $user1 -Password $Password
-            write-host "`nRunning: Start-Migration -JumpCloudUserName $($user2) -SelectedUserName $($user1) -TempPassword $($Password)`n"
+            write-host "`nRunning: Start-Migration -JumpCloudUserName testUser -SelectedUserName testUser -TempPassword $($Password)`n"
             { Start-Migration -JumpCloudAPIKey $env:PESTER_APIKEY -JumpCloudUserName "testUser" -SelectedUserName "$ENV:COMPUTERNAME\testUser" -TempPassword "$($Password)" } | Should -Throw
         }
     }

--- a/jumpcloud-ADMU/Powershell/Tests/Migration.Tests.ps1
+++ b/jumpcloud-ADMU/Powershell/Tests/Migration.Tests.ps1
@@ -356,6 +356,17 @@ Describe 'Migration Test Scenarios' {
             { Start-Migration -JumpCloudAPIKey $env:PESTER_APIKEY -AutobindJCUser $true -JumpCloudUserName "$($user2)" -SelectedUserName "$ENV:COMPUTERNAME\$($user1)" -TempPassword "$($Password)" } | Should -Throw
         }
     }
+    Context 'Start-Migration Fails when LocalUsername and JumpCloudUsername are the same' {
+        It 'local and jumpcloud usernames are the same' {
+            Write-Host "`nStart-Migration Fails when LocalUsername and JumpCloudUsername are the same"
+            $Password = "Temp123!"
+            $user1 = "ADMU_" + -join ((65..90) + (97..122) | Get-Random -Count 5 | ForEach-Object { [char]$_ })
+            $user2 = "ADMU_" + -join ((65..90) + (97..122) | Get-Random -Count 5 | ForEach-Object { [char]$_ })
+            InitUser -UserName $user1 -Password $Password
+            write-host "`nRunning: Start-Migration -JumpCloudUserName $($user2) -SelectedUserName $($user1) -TempPassword $($Password)`n"
+            { Start-Migration -JumpCloudAPIKey $env:PESTER_APIKEY -JumpCloudUserName "testUser" -SelectedUserName "$ENV:COMPUTERNAME\testUser" -TempPassword "$($Password)" } | Should -Throw
+        }
+    }
     Context 'Start-Migration on Local Accounts Expecting Failed Results (Test Reversal Functionallity)' {
         BeforeEach {
             # Remove the log from previous runs


### PR DESCRIPTION
## Issues
* [CUT-3872](https://jumpcloud.atlassian.net/browse/CUT-3872) - CUT-3872-local-jc-username-validation

## What does this solve?
Windows does not allow the same hostname and username. This change adds a validation to given JCUsername and local hostname.
## Is there anything particularly tricky?
n/a
## How should this be tested?
To get the device hostname, on powershell run this command: `hostname`
1. Run Start-Migration -JumpCloudUsername "YOURDeviceHostname" -SelectedUsername "AzureAD/testUser"
2. Validate that this throws an error
![image](https://github.com/TheJumpCloud/jumpcloud-ADMU/assets/97972790/be2819d9-45ae-4424-9a55-ae89abf24e3b)

3. Open form (./start-jcadmu)
4. On the Local Account Username text box enter the device hostname
5. Validate that the migrate profile button is disabled
![image](https://github.com/TheJumpCloud/jumpcloud-ADMU/assets/97972790/fd809a8e-0371-4838-baf8-a15ea7ea4c55)


[CUT-3872]: https://jumpcloud.atlassian.net/browse/CUT-3872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ