### PR TITLE
Cut 3864 fix hybrid leave domain

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,3 +1,12 @@
+## 2.6.7
+
+Release Date: Mar 29, 2024
+
+#### RELEASE NOTES
+
+```
+* Fixes an issue with hybrid unjoin would not leave local domain
+```
 ## 2.6.6
 
 Release Date: Mar 28, 2024

--- a/jumpcloud-ADMU/JumpCloud.ADMU.psd1
+++ b/jumpcloud-ADMU/JumpCloud.ADMU.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'JumpCloud.ADMU.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.6.6'
+    ModuleVersion     = '2.6.7'
 
 
     # Supported PSEditions

--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -143,7 +143,7 @@ function show-mtpSelection {
 <Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="JumpCloud ADMU 2.6.6"
+        Title="JumpCloud ADMU 2.6.7"
         WindowStyle="SingleBorderWindow"
         ResizeMode="NoResize"
         Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" ScrollViewer.HorizontalScrollBarVisibility="Visible" Width="1000" Height="520">

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -2141,7 +2141,7 @@ Function Start-Migration {
                         }
 
                         if ($LocalDomainStatus -match 'NO') {
-                            Write-toLog -message "Left local AD domain successfully. Device Domain State, Local Domain Joined : $LocalDomainStatus"
+                            Write-toLog -message "Local Domain State, Local Domain Joined : $LocalDomainStatus"
                             $admuTracker.leaveDomain.pass = $true
                         } else {
                             Write-ToLog -Message:('Unable to leave local domain using remove-computer...Running UnJoinDomainOrWorkGroup') -Level:('Warn')

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -1383,7 +1383,7 @@ Function Start-Migration {
     Begin {
         Write-ToLog -Message:('####################################' + (get-date -format "dd-MMM-yyyy HH:mm") + '####################################')
         # Start script
-        $admuVersion = '2.6.6'
+        $admuVersion = '2.6.7'
         Write-ToLog -Message:('Running ADMU: ' + 'v' + $admuVersion)
         Write-ToLog -Message:('Script starting; Log file location: ' + $jcAdmuLogFile)
         Write-ToLog -Message:('Gathering system & profile information')


### PR DESCRIPTION
## Issues
* [CUT-3864](https://jumpcloud.atlassian.net/browse/CUT-3864) - CUT-3864-Fix-Hybrid-Leave-Domain

## What does this solve?
Fixes an issue with Hybrid leave not unjoining local AD domain. This change adds validation check and retry for both Azure AD and Local Domain leave
## Is there anything particularly tricky?
Need hybrid AD to test
## How should this be tested?
1. Comment out line 2104 or `Remove-Computer -force` to simulate both Azure AD and local domain not unjoining.
2. Check that hybrid is unjoined
![image](https://github.com/TheJumpCloud/jumpcloud-ADMU/assets/97972790/451e5ed4-718c-41c4-987a-edf8d35a9601)


[CUT-3864]: https://jumpcloud.atlassian.net/browse/CUT-3864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ