### PR TITLE
Remove Production ENV from CI

### DIFF
--- a/.github/workflows/admu-ci.yml
+++ b/.github/workflows/admu-ci.yml
@@ -109,7 +109,6 @@ jobs:
   Build-Module:
     needs: ["Setup-Build-Dependancies", "Check-PR-Labels"]
     runs-on: windows-latest
-    environment: Production
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Issues
* [CUT-4060](https://jumpcloud.atlassian.net/browse/CUT-4060) - Remove Production ENV From CI Task

## What does this solve?

The production environment was left in the CI task while testing the latest changes to our release task. This one liner change simply removes the environment from the CI test job. It remains in the release job.

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots

[CUT-4060]: https://jumpcloud.atlassian.net/browse/CUT-4060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ