### PR TITLE
CUT-4223-LeaveLocalDomainFix

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,6 +1,6 @@
 ## 2.7.3
 
-Release Date: July 24, 2024
+Release Date: July 25, 2024
 
 #### RELEASE NOTES
 

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,3 +1,14 @@
+## 2.7.3
+
+Release Date: July 24, 2024
+
+#### RELEASE NOTES
+
+#### Bug Fixes:
+
+```
+* Fixed an issue with leave local AD
+```
 ## 2.7.2
 
 Release Date: July 16, 2024

--- a/jumpcloud-ADMU/JumpCloud.ADMU.psd1
+++ b/jumpcloud-ADMU/JumpCloud.ADMU.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.7.2'
+    ModuleVersion     = '2.7.3'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -153,7 +153,7 @@ function show-mtpSelection {
 <Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="JumpCloud ADMU 2.7.2"
+        Title="JumpCloud ADMU 2.7.3"
         WindowStyle="SingleBorderWindow"
         ResizeMode="NoResize"
         Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" ScrollViewer.HorizontalScrollBarVisibility="Visible" Width="1020" Height="590">

--- a/jumpcloud-ADMU/Powershell/ProgressForm.ps1
+++ b/jumpcloud-ADMU/Powershell/ProgressForm.ps1
@@ -37,7 +37,7 @@ function New-ProgressForm {
     <Window
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Name="Window" Title="JumpCloud ADMU 2.7.2"
+    Name="Window" Title="JumpCloud ADMU 2.7.3"
     WindowStyle="SingleBorderWindow"
     ResizeMode="NoResize"
     Background="White" Width="720" Height="540">

--- a/jumpcloud-ADMU/Powershell/ProgressForm.ps1
+++ b/jumpcloud-ADMU/Powershell/ProgressForm.ps1
@@ -40,7 +40,7 @@ function New-ProgressForm {
     Name="Window" Title="JumpCloud ADMU 2.7.3"
     WindowStyle="SingleBorderWindow"
     ResizeMode="NoResize"
-    Background="White" Width="720" Height="540">
+    Background="White" Width="720" Height="550  ">
     <Window.Resources>
         <Style x:Key="NoHeaderGroupBoxStyle" TargetType="{x:Type GroupBox}">
             <Setter Property="Template">

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -1869,7 +1869,7 @@ Function Start-Migration {
         $AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signed.msi"
         $AGENT_INSTALLER_PATH = "$windowsDrive\windows\Temp\JCADMU\jcagent-msi-signed.msi"
         $AGENT_CONF_PATH = "$($AGENT_PATH)\Plugins\Contrib\jcagent.conf"
-        $admuVersion = '2.7.2'
+        $admuVersion = '2.7.3'
 
         $script:AdminDebug = $AdminDebug
         $isForm = $PSCmdlet.ParameterSetName -eq "form"
@@ -2764,10 +2764,11 @@ Function Start-Migration {
             foreach ($line in $ADStatus) {
                 if ($line -match "AzureADJoined : ") {
                     $AzureADStatus = ($line.trimstart('AzureADJoined : '))
+                    Write-ToLog "AzureAD Status: $AzureADStatus"
                 }
                 if ($line -match "DomainJoined : ") {
-
-                    $AzureDomainStatus = ($line.trimstart('DomainJoined : '))
+                    $LocalDomainStatus = ($line.trimstart('DomainJoined : '))
+                    Write-ToLog "Local Domain Status: $LocalDomainStatus"
                 }
             }
             Write-ToProgress -ProgressBar $Progressbar -Status "CheckADStatus" -form $isForm

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -1833,6 +1833,20 @@ function Get-ProfileSize {
     Write-ToLog -Message:("Profile Size: $totalSizeGB GB")
     return $totalSizeGB
 }
+
+function Get-DomainStatus {
+    $ADStatus = dsregcmd.exe /status
+    foreach ($line in $ADStatus) {
+        if ($line -match "AzureADJoined : ") {
+            $AzureADStatus = ($line.trimstart('AzureADJoined : '))
+        }
+        if ($line -match "DomainJoined : ") {
+            $LocalDomainStatus = ($line.trimstart('DomainJoined : '))
+        }
+    }
+    # Return both statuses
+    return $AzureADStatus, $LocalDomainStatus
+}
 Function Start-Migration {
     [CmdletBinding(HelpURI = "https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Start-Migration")]
     Param (
@@ -2758,22 +2772,9 @@ Function Start-Migration {
             }
             $appxList = @()
 
-            # Get Azure AD Status
-
-            $ADStatus = dsregcmd.exe /status
-            foreach ($line in $ADStatus) {
-                if ($line -match "AzureADJoined : ") {
-                    $AzureADStatus = ($line.trimstart('AzureADJoined : '))
-                    Write-ToLog "AzureAD Status: $AzureADStatus"
-                }
-                if ($line -match "DomainJoined : ") {
-                    $LocalDomainStatus = ($line.trimstart('DomainJoined : '))
-                    Write-ToLog "Local Domain Status: $LocalDomainStatus"
-                }
-            }
             Write-ToProgress -ProgressBar $Progressbar -Status "CheckADStatus" -form $isForm
-
-            Write-ToLog "AzureAD Status: $AzureADStatus" -Level Verbose
+            # Get Azure AD Status
+            $AzureADStatus, $LocalDomainStatus = Get-DomainStatus
 
             if ($AzureADStatus -eq 'YES' -or $netBiosName -match 'AzureAD') {
                 # Find Appx User Apps by Username
@@ -2843,71 +2844,66 @@ Function Start-Migration {
 
             $WmiComputerSystem = Get-WmiObject -Class:('Win32_ComputerSystem')
             if ($LeaveDomain -eq $true) {
-                if ($AzureADStatus -match 'YES' -or $LocalDomainStatus -match 'YES') {
-                    try {
-                        if ($LocalDomainStatus -match 'NO') {
+                if ($AzureADStatus -match 'YES' -and $LocalDomainStatus -match 'YES') {
+                    Write-ToLog -Message:('Device is HYBRID joined')
+                    $ADJoined = "Hybrid"
+                } elseif ($AzureADStatus -match 'NO' -and $LocalDomainStatus -match 'Yes') {
+                    Write-ToLog -Message:('Device is Local Domain joined')
+                    $ADJoined = "LocalJoined"
+                } elseif ($AzureADStatus -match 'YES' -and $LocalDomainStatus -match 'NO') {
+                    Write-ToLog -Message:('Device is Azure AD joined')
+                    $ADJoined = "AzureADJoined"
+                }
+                if ($ADJoined) {
+                    switch ($ADJoined) {
+                        "Hybrid" {
+                            Remove-Computer -force #LeaveHybrid
+                            $AzureADStatus, $LocalDomainStatus = Get-DomainStatus
+                            if ($AzureADStatus -match 'NO' -and $LocalDomainStatus -match 'NO') {
+                                Write-ToLog -Message:('Left Hybrid Domain successfully') -Level:('Info')
+                                $admuTracker.leaveDomain.pass = $true
+                            } else {
+                                Write-ToLog -Message:('Unable to leave Hybrid Domain') -Level:('Warn')
+                                $admuTracker.leaveDomain.fail = $true
+                            }
+                        }
+                        "LocalJoined" {
+                            $WmiComputerSystem.UnJoinDomainOrWorkGroup($null, $null, 0)
+                            $AzureADStatus, $LocalDomainStatus = Get-DomainStatus
+                            if ($AzureADStatus -match 'NO' -and $LocalDomainStatus -match 'NO') {
+                                Write-ToLog -Message:('Left local domain successfully') -Level:('Info')
+                                $admuTracker.leaveDomain.pass = $true
+                            } else {
+                                Write-ToLog -Message:('Unable to leave local domain') -Level:('Warn')
+                                $admuTracker.leaveDomain.fail = $true
+                            }
+                        }
+                        "AzureADJoined" {
                             dsregcmd.exe /leave # Leave Azure AD
-                        } else {
-                            Remove-Computer -force #Leave local AD or Hybrid
-                        }
-                    } catch {
-                        Write-ToLog -Message:('Unable to leave domain, JumpCloud agent will not start until resolved') -Level:('Warn')
-                    }
-                    # Get Azure AD Status
-                    $ADStatus = dsregcmd.exe /status
-                    foreach ($line in $ADStatus) {
-                        if ($line -match "AzureADJoined : ") {
-                            $AzureADStatus = ($line.trimstart('AzureADJoined : '))
-                        }
-                        if ($line -match "DomainJoined : ") {
-                            $LocalDomainStatus = ($line.trimstart('DomainJoined : '))
-                        }
-                    }
-                    # Check Azure AD status after running dsregcmd.exe /leave as NTAUTHORITY\SYSTEM
-                    if ($AzureADStatus -match 'NO') {
-                        Write-toLog -message "Left Azure AD domain successfully. Device Domain State, AzureADJoined : $AzureADStatus"
-                        $admuTracker.leaveDomain.pass = $true
-                    } else {
-                        Write-ToLog -Message:('Unable to leave Azure Domain. Re-running dsregcmd.exe /leave') -Level:('Warn')
-                        dsregcmd.exe /leave # Leave Azure AD
+                            # Get Azure AD Status after running dsregcmd.exe /leave
+                            $AzureADStatus = Get-DomainStatus
+                            # Check Azure AD status after running dsregcmd.exe /leave as NTAUTHORITY\SYSTEM
+                            if ($AzureADStatus -match 'NO') {
+                                Write-toLog -message "Left Azure AD domain successfully. Device Domain State, AzureADJoined : $AzureADStatus"
+                                $admuTracker.leaveDomain.pass = $true
+                            } else {
+                                Write-ToLog -Message:('Unable to leave Azure Domain. Re-running dsregcmd.exe /leave') -Level:('Warn')
+                                dsregcmd.exe /leave # Leave Azure AD
 
-                        $ADStatus = dsregcmd.exe /status
-                        foreach ($line in $ADStatus) {
-                            if ($line -match "AzureADJoined : ") {
-                                $AzureADStatus = ($line.trimstart('AzureADJoined : '))
+                                $AzureADStatus = Get-DomainStatus
+                                if ($AzureADStatus -match 'NO') {
+                                    Write-ToLog -Message:('Left Azure AD domain successfully') -Level:('Info')
+                                    $admuTracker.leaveDomain.pass = $true
+                                } else {
+                                    Write-ToLog -Message:('Unable to leave Azure AD domain') -Level:('Warn')
+                                    $admuTracker.leaveDomain.fail = $true
+                                }
+
                             }
                         }
-                        if ($AzureADStatus -match 'NO') {
-                            Write-ToLog -Message:('Left Azure AD domain successfully') -Level:('Info')
-                            $admuTracker.leaveDomain.pass = $true
-                        } else {
-                            Write-ToLog -Message:('Unable to leave Azure AD domain') -Level:('Warn')
-                            $admuTracker.leaveDomain.fail = $true
-                        }
-
                     }
-
-                    if ($LocalDomainStatus -match 'NO') {
-                        Write-toLog -message "Local Domain State, Local Domain Joined : $LocalDomainStatus"
-                        $admuTracker.leaveDomain.pass = $true
-                    } else {
-                        Write-ToLog -Message:('Unable to leave local domain using remove-computer...Running UnJoinDomainOrWorkGroup') -Level:('Warn')
-                        $WmiComputerSystem.UnJoinDomainOrWorkGroup($null, $null, 0)
-
-                        $ADStatus = dsregcmd.exe /status
-                        foreach ($line in $ADStatus) {
-                            if ($line -match "DomainJoined : ") {
-                                $LocalDomainStatus = ($line.trimstart('DomainJoined : '))
-                            }
-                        }
-                        if ($LocalDomainStatus -match 'NO') {
-                            Write-ToLog -Message:('Left local domain successfully') -Level:('Info')
-                            $admuTracker.leaveDomain.pass = $true
-                        } else {
-                            Write-ToLog -Message:('Unable to leave local domain') -Level:('Warn')
-                            $admuTracker.leaveDomain.fail = $true
-                        }
-                    }
+                } else {
+                    Write-ToLog -Message:('Device is not joined to a domain, skipping leave domain step')
                 }
             }
 


### PR DESCRIPTION
## Issues
* [CUT-4223](https://jumpcloud.atlassian.net/browse/CUT-4223) - CUT-4223 Leave Local Domain Bug Fix

## What does this solve?
This change fixes the issue where $LocalDomainStatus not initialized which causes an issue when an admin is trying to leave a non-AzureAD domain/local domain
## Is there anything particularly tricky?
n/a
## How should this be tested?
1. Run this version of ADMU with `-LeaveDomain` checked in a local AD domain joined machine.
2. After a successful migration, run `dsregcmd.exe /status` on powershell, device state should have `DomainJoined : NO` or the ADMU log should have this message: `Local Domain State, Local Domain Joined : NO`
## Screenshots

[CUT-4223]: https://jumpcloud.atlassian.net/browse/CUT-4223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ