### PR TITLE
fix issue with disabled migrate button (#137)

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -8,7 +8,7 @@ This fixes an issue with disabled Migrate Button
 
 #### Bug Fixes:
 ```
-* Fixed an issue with Migrate Button disabled when there is a username is inputted before JC API key
+* Fixed an issue with ADMU UI "Migrate Profile" button where it remained disabled even though all the required fields were satisfied.
 ```
 ## 2.7.5
 

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,3 +1,15 @@
+## 2.7.6
+
+Release Date: August 21, 2024
+
+#### RELEASE NOTES
+
+This fixes an issue with disabled Migrate Button
+
+#### Bug Fixes:
+```
+* Fixed an issue with Migrate Button disabled when there is a username is inputted before JC API key
+```
 ## 2.7.5
 
 Release Date: August 21, 2024

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -12,7 +12,7 @@ This fixes an issue with disabled Migrate Button
 ```
 ## 2.7.5
 
-Release Date: August 21, 2024
+Release Date: August 28, 2024
 
 #### RELEASE NOTES
 

--- a/jumpcloud-ADMU/JumpCloud.ADMU.psd1
+++ b/jumpcloud-ADMU/JumpCloud.ADMU.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.7.5'
+    ModuleVersion     = '2.7.6'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -739,11 +739,7 @@ $tbJumpCloudAPIKey.Add_PasswordChanged( {
                 $tbJumpCloudAPIKey.BorderBrush = "#FFC6CBCF"
                 $img_apikey_valid.Source = DecodeBase64Image -ImageBase64 $ActiveBase64
                 $img_apikey_valid.ToolTip = $null
-                # If connect key is populated, and jumpcloudusername is populated, and autobindjcuser is checked
-                if ($tbJumpCloudAPIKey -and $tbJumpCloudUserName.Text) {
-                    # Enable migration button
-                    $script:bMigrateProfile.IsEnabled = $true
-                }
+                Test-Button -tbJumpCloudUserName:($tbJumpCloudUserName) -tbJumpCloudConnectKey:($tbJumpCloudConnectKey) -tbTempPassword:($tbTempPassword) -lvProfileList:($lvProfileList) -tbJumpCloudAPIKey:($tbJumpCloudAPIKey)
             } catch {
                 $OrgSelection = ""
                 $lbl_orgName.Text = ""

--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -153,7 +153,7 @@ function show-mtpSelection {
 <Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="JumpCloud ADMU 2.7.5"
+        Title="JumpCloud ADMU 2.7.6"
         WindowStyle="SingleBorderWindow"
         ResizeMode="NoResize"
         Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" ScrollViewer.HorizontalScrollBarVisibility="Visible" Width="1020" Height="590">
@@ -628,7 +628,7 @@ $cb_autobindjcuser.Add_Checked( { $img_apikey_valid.Visibility = 'Visible' })
 $cb_autobindjcuser.Add_Checked( { $cb_bindAsAdmin.IsEnabled = $true })
 $cb_bindAsAdmin.Add_Checked( { $script:BindAsAdmin = $true })
 $cb_autobindjcuser.Add_Checked( {
-        Test-Button -tbJumpCloudUserName:($tbJumpCloudUserName) -tbJumpCloudConnectKey:($tbJumpCloudConnectKey) -tbJumpCloudConnectAPIKey:($tbJumpCloudAPIKey) -tbTempPassword:($tbTempPassword) -lvProfileList:($lvProfileList) -tbJumpCloudAPIKey:($tbJumpCloudAPIKey)
+        Test-Button -tbJumpCloudUserName:($tbJumpCloudUserName) -tbJumpCloudConnectKey:($tbJumpCloudConnectKey) -tbTempPassword:($tbTempPassword) -lvProfileList:($lvProfileList) -tbJumpCloudAPIKey:($tbJumpCloudAPIKey)
         If (((Test-CharLen -len 40 -testString $tbJumpCloudAPIKey.Password) -and (Test-HasNoSpace $tbJumpCloudAPIKey.Password)) -eq $false) {
             #$tbJumpCloudAPIKey.Tooltip = "API Key Must be 40chars & Not Contain Spaces"
             $tbJumpCloudAPIKey.Background = "#FFC6CBCF"
@@ -651,7 +651,7 @@ $cb_autobindjcuser.Add_Unchecked( { $cb_bindAsAdmin.IsEnabled = $false })
 $cb_autobindjcuser.Add_Unchecked( { $cb_bindAsAdmin.IsChecked = $false })
 $cb_bindAsAdmin.Add_Unchecked( { $script:BindAsAdmin = $false })
 $cb_autobindjcuser.Add_Unchecked( {
-        Test-Button -tbJumpCloudUserName:($tbJumpCloudUserName) -tbJumpCloudConnectKey:($tbJumpCloudConnectKey) -tbJumpCloudConnectAPIKey:($tbJumpCloudAPIKey) -tbTempPassword:($tbTempPassword) -lvProfileList:($lvProfileList) -tbJumpCloudAPIKey:($tbJumpCloudAPIKey)
+        Test-Button -tbJumpCloudUserName:($tbJumpCloudUserName) -tbJumpCloudConnectKey:($tbJumpCloudConnectKey) -tbTempPassword:($tbTempPassword) -lvProfileList:($lvProfileList) -tbJumpCloudAPIKey:($tbJumpCloudAPIKey)
         If (((Test-CharLen -len 40 -testString $tbJumpCloudAPIKey.Password) -and (Test-HasNoSpace $tbJumpCloudAPIKey.Password) -or ($cb_autobindjcuser.IsEnabled)) -eq $false) {
             #$tbJumpCloudAPIKey.Tooltip = "API Key Must be 40chars & Not Contain Spaces"
             $tbJumpCloudAPIKey.Background = "#FFC6CBCF"
@@ -720,8 +720,7 @@ $tbJumpCloudConnectKey.Add_PasswordChanged( {
     })
 
 $tbJumpCloudAPIKey.Add_PasswordChanged( {
-        Test-Button -tbJumpCloudUserName:($tbJumpCloudUserName) -tbJumpCloudConnectKey:($tbJumpCloudConnectKey) -tbJumpCloudConnectAPIKey:($tbJumpCloudAPIKey) -tbTempPassword:($tbTempPassword) -lvProfileList:($lvProfileList) -tbJumpCloudAPIKey:($tbJumpCloudAPIKey)
-
+        Test-Button -tbJumpCloudUserName:($tbJumpCloudUserName) -tbJumpCloudConnectKey:($tbJumpCloudConnectKey) -tbTempPassword:($tbTempPassword) -lvProfileList:($lvProfileList) -tbJumpCloudAPIKey:($tbJumpCloudAPIKey)
         If (((Test-CharLen -len 40 -testString $tbJumpCloudAPIKey.Password) -and (Test-HasNoSpace $tbJumpCloudAPIKey.Password)) -eq $false) {
             $tbJumpCloudAPIKey.Background = "#FFC6CBCF"
             $tbJumpCloudAPIKey.BorderBrush = "#FFF90000"
@@ -740,6 +739,11 @@ $tbJumpCloudAPIKey.Add_PasswordChanged( {
                 $tbJumpCloudAPIKey.BorderBrush = "#FFC6CBCF"
                 $img_apikey_valid.Source = DecodeBase64Image -ImageBase64 $ActiveBase64
                 $img_apikey_valid.ToolTip = $null
+                # If connect key is populated, and jumpcloudusername is populated, and autobindjcuser is checked
+                if ($tbJumpCloudAPIKey -and $tbJumpCloudUserName.Text) {
+                    # Enable migration button
+                    $script:bMigrateProfile.IsEnabled = $true
+                }
             } catch {
                 $OrgSelection = ""
                 $lbl_orgName.Text = ""

--- a/jumpcloud-ADMU/Powershell/ProgressForm.ps1
+++ b/jumpcloud-ADMU/Powershell/ProgressForm.ps1
@@ -37,7 +37,7 @@ function New-ProgressForm {
     <Window
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Name="Window" Title="JumpCloud ADMU 2.7.5"
+    Name="Window" Title="JumpCloud ADMU 2.7.6"
     WindowStyle="SingleBorderWindow"
     ResizeMode="NoResize"
     Background="White" Width="720" Height="550  ">

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -1883,7 +1883,7 @@ Function Start-Migration {
         $AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signed.msi"
         $AGENT_INSTALLER_PATH = "$windowsDrive\windows\Temp\JCADMU\jcagent-msi-signed.msi"
         $AGENT_CONF_PATH = "$($AGENT_PATH)\Plugins\Contrib\jcagent.conf"
-        $admuVersion = '2.7.5'
+        $admuVersion = '2.7.6'
 
         $script:AdminDebug = $AdminDebug
         $isForm = $PSCmdlet.ParameterSetName -eq "form"


### PR DESCRIPTION
## Issues
* [CUT-4254](https://jumpcloud.atlassian.net/browse/CUT-4254) - CUT-4254-Disabled-Migrate-Button-Bug

## What does this solve?
-Fixes an issue with disabled migrate button when username is inputted before JC API key
-Removed unused Test-Button parameters
## Is there anything particularly tricky?
n/a
## How should this be tested?
1. Run the app
2. Select domain profile
3. Input username
4. Check both `Install JCAgent` and `Autobind JC User`
5. Input Connect Key
6. Input API Key 
7. Migrate button should be enabled

[CUT-4254]: https://jumpcloud.atlassian.net/browse/CUT-4254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ