### PR TITLE
Cut 4292 unresponsive search

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,3 +1,15 @@
+## 2.7.7
+
+Release Date: September 25, 2024
+
+#### RELEASE NOTES
+
+This release fixes an issue with users unable to use Search on Windows 10
+
+#### Bug Fixes:
+```
+* Resolved an issue causing Windows 10 Search to fail or become unresponsive for users after migration.
+```
 ## 2.7.6
 
 Release Date: August 21, 2024

--- a/jumpcloud-ADMU/JumpCloud.ADMU.psd1
+++ b/jumpcloud-ADMU/JumpCloud.ADMU.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.7.6'
+    ModuleVersion     = '2.7.7'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -153,7 +153,7 @@ function show-mtpSelection {
 <Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="JumpCloud ADMU 2.7.6"
+        Title="JumpCloud ADMU 2.7.7"
         WindowStyle="SingleBorderWindow"
         ResizeMode="NoResize"
         Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" ScrollViewer.HorizontalScrollBarVisibility="Visible" Width="1020" Height="590">

--- a/jumpcloud-ADMU/Powershell/ProgressForm.ps1
+++ b/jumpcloud-ADMU/Powershell/ProgressForm.ps1
@@ -37,7 +37,7 @@ function New-ProgressForm {
     <Window
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Name="Window" Title="JumpCloud ADMU 2.7.6"
+    Name="Window" Title="JumpCloud ADMU 2.7.7"
     WindowStyle="SingleBorderWindow"
     ResizeMode="NoResize"
     Background="White" Width="720" Height="550  ">

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -1883,7 +1883,7 @@ Function Start-Migration {
         $AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signed.msi"
         $AGENT_INSTALLER_PATH = "$windowsDrive\windows\Temp\JCADMU\jcagent-msi-signed.msi"
         $AGENT_CONF_PATH = "$($AGENT_PATH)\Plugins\Contrib\jcagent.conf"
-        $admuVersion = '2.7.6'
+        $admuVersion = '2.7.7'
 
         $script:AdminDebug = $AdminDebug
         $isForm = $PSCmdlet.ParameterSetName -eq "form"
@@ -2766,7 +2766,7 @@ Function Start-Migration {
 
             Write-ToLog -Message:('Updating UWP Apps for new user') -Level Verbose
             $newUserProfileImagePath = Get-ItemPropertyValue -Path ('HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\' + $newusersid) -Name 'ProfileImagePath'
-            # IF windows 10
+            # IF windows 10 remove the windows.search then it will be recreated on login
             if ($systemVersion.OSName -match "Windows 10") {
                 $searchFolder = "$newUserProfileImagePath\AppData\Local\Packages\Microsoft.Windows.Search_cw5n1h2txyewy"
                 Write-ToLog -Message:('Removing Windows.Search_ folder' + $searchFolder)

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -2767,7 +2767,7 @@ Function Start-Migration {
             Write-ToLog -Message:('Updating UWP Apps for new user') -Level Verbose
             $newUserProfileImagePath = Get-ItemPropertyValue -Path ('HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\' + $newusersid) -Name 'ProfileImagePath'
             # IF windows 10
-            if ($systemVersion.OSName -eq "Windows 10") {
+            if ($systemVersion.OSName -match "Windows 10") {
                 $searchFolder = "$newUserProfileImagePath\AppData\Local\Packages\Microsoft.Windows.Search_cw5n1h2txyewy"
                 Write-ToLog -Message:('Removing Windows.Search_ folder' + $searchFolder)
                 if (Test-Path $searchFolder) {

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -2737,6 +2737,16 @@ Function Start-Migration {
             Write-ToProgress -ProgressBar $Progressbar -Status "CreateRegEntries" -form $isForm
 
             Write-ToLog -Message:('Creating HKLM Registry Entries') -Level Verbose
+            # IF windows 10
+            if ($systemVersion.OSName -eq "Windows 10") {
+                $searchFolder = "$newUserProfileImagePath\AppData\Local\Packages\Microsoft.Windows.Search_cw5n1h2txyewy"
+                Write-ToLog -Message:('Removing Windows.Search_ folder' + $searchFolder)
+                if (Test-Path $searchFolder) {
+                    Remove-Item -Path $searchFolder -Recurse -Force
+                }
+            }
+
+
             # Root Key Path
             $ADMUKEY = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\ADMU-AppxPackage"
             # Remove Root from key to pass into functions

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -2298,14 +2298,6 @@ Function Start-Migration {
                         write-ToLog -Message:("key not found $key")
                     }
                 }
-
-                # Remove Windows.Search_ folder
-
-                $searchFolder = "$newUserProfileImagePath\AppData\Local\Packages\Microsoft.Windows.Search_cw5n1h2txyewy"
-                Write-ToLog -Message:('Removing Windows.Search_ folder' + $searchFolder)
-                if (Test-Path $searchFolder) {
-                    Remove-Item -Path $searchFolder -Recurse -Force
-                }
             }
 
             Write-ToProgress -ProgressBar $Progressbar -Status "CopyUserRegFiles" -form $isForm
@@ -2737,15 +2729,6 @@ Function Start-Migration {
             Write-ToProgress -ProgressBar $Progressbar -Status "CreateRegEntries" -form $isForm
 
             Write-ToLog -Message:('Creating HKLM Registry Entries') -Level Verbose
-            # IF windows 10
-            if ($systemVersion.OSName -eq "Windows 10") {
-                $searchFolder = "$newUserProfileImagePath\AppData\Local\Packages\Microsoft.Windows.Search_cw5n1h2txyewy"
-                Write-ToLog -Message:('Removing Windows.Search_ folder' + $searchFolder)
-                if (Test-Path $searchFolder) {
-                    Remove-Item -Path $searchFolder -Recurse -Force
-                }
-            }
-
 
             # Root Key Path
             $ADMUKEY = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\ADMU-AppxPackage"
@@ -2783,7 +2766,14 @@ Function Start-Migration {
 
             Write-ToLog -Message:('Updating UWP Apps for new user') -Level Verbose
             $newUserProfileImagePath = Get-ItemPropertyValue -Path ('HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\' + $newusersid) -Name 'ProfileImagePath'
-
+            # IF windows 10
+            if ($systemVersion.OSName -eq "Windows 10") {
+                $searchFolder = "$newUserProfileImagePath\AppData\Local\Packages\Microsoft.Windows.Search_cw5n1h2txyewy"
+                Write-ToLog -Message:('Removing Windows.Search_ folder' + $searchFolder)
+                if (Test-Path $searchFolder) {
+                    Remove-Item -Path $searchFolder -Recurse -Force
+                }
+            }
             $path = $newUserProfileImagePath + '\AppData\Local\JumpCloudADMU'
             If (!(test-path $path)) {
                 New-Item -ItemType Directory -Force -Path $path

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -2298,6 +2298,14 @@ Function Start-Migration {
                         write-ToLog -Message:("key not found $key")
                     }
                 }
+
+                # Remove Windows.Search_ folder
+
+                $searchFolder = "$newUserProfileImagePath\AppData\Local\Packages\Microsoft.Windows.Search_cw5n1h2txyewy"
+                Write-ToLog -Message:('Removing Windows.Search_ folder' + $searchFolder)
+                if (Test-Path $searchFolder) {
+                    Remove-Item -Path $searchFolder -Recurse -Force
+                }
             }
 
             Write-ToProgress -ProgressBar $Progressbar -Status "CopyUserRegFiles" -form $isForm


### PR DESCRIPTION
## Issues
* [CUT-4292](https://jumpcloud.atlassian.net/browse/cut-4292) - CUT-4292-Unresponsive-Search
## What does this solve?
Recent Windows update broke migrated users ability to use the Search bar functionality for Windows 10 devices. This fix deletes the Windows search appdata files which then gets recreated once the migrated user log in.
## Is there anything particularly tricky?
Running the tool on Windows 10
## How should this be tested?
1. Spin up Windows 10
2. Make sure it is fully updated
3. Run ADMU migration
4. Login to the migrated user. Validate that the Search is functioning properly and able to do internet searches.