### PR TITLE
Cut 4292 unresponsive search (#140)

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,3 +1,15 @@
+## 2.7.7
+
+Release Date: September 25, 2024
+
+#### RELEASE NOTES
+
+This release fixes an issue with users unable to use Search on Windows 10
+
+#### Bug Fixes:
+```
+* Resolved an issue causing Windows 10 Search to fail or become unresponsive for users after migration.
+```
 ## 2.7.6
 
 Release Date: August 21, 2024

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -4,7 +4,7 @@ Release Date: September 25, 2024
 
 #### RELEASE NOTES
 
-This release fixes an issue with users unable to use Search on Windows 10
+This release resolves an issue on Windows 10 systems where users were unable to use the search bar post-migration
 
 #### Bug Fixes:
 ```

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -8,7 +8,7 @@ This release fixes an issue with users unable to use Search on Windows 10
 
 #### Bug Fixes:
 ```
-* Resolved an issue causing Windows 10 Search to fail or become unresponsive for users after migration.
+* Resolves an issue on Windows 10 systems where users were unable to use the search bar post-migration
 ```
 ## 2.7.6
 

--- a/jumpcloud-ADMU/JumpCloud.ADMU.psd1
+++ b/jumpcloud-ADMU/JumpCloud.ADMU.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.7.6'
+    ModuleVersion     = '2.7.7'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -153,7 +153,7 @@ function show-mtpSelection {
 <Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="JumpCloud ADMU 2.7.6"
+        Title="JumpCloud ADMU 2.7.7"
         WindowStyle="SingleBorderWindow"
         ResizeMode="NoResize"
         Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" ScrollViewer.HorizontalScrollBarVisibility="Visible" Width="1020" Height="590">

--- a/jumpcloud-ADMU/Powershell/ProgressForm.ps1
+++ b/jumpcloud-ADMU/Powershell/ProgressForm.ps1
@@ -37,7 +37,7 @@ function New-ProgressForm {
     <Window
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Name="Window" Title="JumpCloud ADMU 2.7.6"
+    Name="Window" Title="JumpCloud ADMU 2.7.7"
     WindowStyle="SingleBorderWindow"
     ResizeMode="NoResize"
     Background="White" Width="720" Height="550  ">

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -1883,7 +1883,7 @@ Function Start-Migration {
         $AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signed.msi"
         $AGENT_INSTALLER_PATH = "$windowsDrive\windows\Temp\JCADMU\jcagent-msi-signed.msi"
         $AGENT_CONF_PATH = "$($AGENT_PATH)\Plugins\Contrib\jcagent.conf"
-        $admuVersion = '2.7.6'
+        $admuVersion = '2.7.7'
 
         $script:AdminDebug = $AdminDebug
         $isForm = $PSCmdlet.ParameterSetName -eq "form"
@@ -2729,6 +2729,7 @@ Function Start-Migration {
             Write-ToProgress -ProgressBar $Progressbar -Status "CreateRegEntries" -form $isForm
 
             Write-ToLog -Message:('Creating HKLM Registry Entries') -Level Verbose
+
             # Root Key Path
             $ADMUKEY = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\ADMU-AppxPackage"
             # Remove Root from key to pass into functions
@@ -2765,7 +2766,14 @@ Function Start-Migration {
 
             Write-ToLog -Message:('Updating UWP Apps for new user') -Level Verbose
             $newUserProfileImagePath = Get-ItemPropertyValue -Path ('HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\' + $newusersid) -Name 'ProfileImagePath'
-
+            # IF windows 10 remove the windows.search then it will be recreated on login
+            if ($systemVersion.OSName -match "Windows 10") {
+                $searchFolder = "$newUserProfileImagePath\AppData\Local\Packages\Microsoft.Windows.Search_cw5n1h2txyewy"
+                Write-ToLog -Message:('Removing Windows.Search_ folder' + $searchFolder)
+                if (Test-Path $searchFolder) {
+                    Remove-Item -Path $searchFolder -Recurse -Force
+                }
+            }
             $path = $newUserProfileImagePath + '\AppData\Local\JumpCloudADMU'
             If (!(test-path $path)) {
                 New-Item -ItemType Directory -Force -Path $path


### PR DESCRIPTION
## Issues
* [CUT-4292](https://jumpcloud.atlassian.net/browse/cut-4292) - CUT-4292-Unresponsive-Search
## What does this solve?
Recent Windows update broke migrated users ability to use the Search bar functionality for Windows 10 devices. This fix deletes the Windows search appdata files which then gets recreated once the migrated user log in.
## Is there anything particularly tricky?
Running the tool on Windows 10
## How should this be tested?
1. Spin up Windows 10
2. Make sure it is fully updated
3. Run ADMU migration
4. Login to the migrated user. Validate that the Search is functioning properly and able to do internet searches.

[CUT-4292]: https://jumpcloud.atlassian.net/browse/CUT-4292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ