### PR TITLE
V2.7.8 — Add system details to log and prevent overall failures if the leave domain step fails

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,3 +1,11 @@
+## 2.7.8
+
+Release Date: October 2, 2024
+
+#### RELEASE NOTES
+
+This release adds Windows OS version, edition, and build number information to the log
+
 ## 2.7.7
 
 Release Date: September 25, 2024

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,10 +1,17 @@
 ## 2.7.8
 
-Release Date: October 2, 2024
+Release Date: October 14, 2024
 
 #### RELEASE NOTES
 
+This release prevents the ADMU from considering the migration a failure if the leave domain step does not complete as expected.
 This release adds Windows OS version, edition, and build number information to the log
+
+#### Bug Fixes:
+
+```
+* When the ADMU encounters an issue with leaving the domain, the tool would mark this step a failure and attempt to revert the newly created user. In doing so the account being migrated was erroneously removed. This release allows for the leave domain step to fail but does not consider the failure of that step to be an overall migration failure. Migration can still succeed if the system fails to leave the domain for any reason.
+```
 
 ## 2.7.7
 

--- a/jumpcloud-ADMU/JumpCloud.ADMU.psd1
+++ b/jumpcloud-ADMU/JumpCloud.ADMU.psd1
@@ -13,7 +13,7 @@
 
     # Version number of this module.
 
-    ModuleVersion     = '2.7.7'
+    ModuleVersion     = '2.7.8'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/jumpcloud-ADMU/Powershell/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Form.ps1
@@ -153,7 +153,7 @@ function show-mtpSelection {
 <Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="JumpCloud ADMU 2.7.7"
+        Title="JumpCloud ADMU 2.7.8"
         WindowStyle="SingleBorderWindow"
         ResizeMode="NoResize"
         Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" ScrollViewer.HorizontalScrollBarVisibility="Visible" Width="1020" Height="590">

--- a/jumpcloud-ADMU/Powershell/ProgressForm.ps1
+++ b/jumpcloud-ADMU/Powershell/ProgressForm.ps1
@@ -37,7 +37,7 @@ function New-ProgressForm {
     <Window
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Name="Window" Title="JumpCloud ADMU 2.7.7"
+    Name="Window" Title="JumpCloud ADMU 2.7.8"
     WindowStyle="SingleBorderWindow"
     ResizeMode="NoResize"
     Background="White" Width="720" Height="550  ">

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -1871,7 +1871,7 @@ Function Start-Migration {
         $netBiosName = Get-NetBiosName
         $WmiComputerSystem = Get-WmiObject -Class:('Win32_ComputerSystem')
         $localComputerName = $WmiComputerSystem.Name
-        $systemVersion = Get-ComputerInfo | Select-Object OSName, OSVersion, OsHardwareAbstractionLayer
+        $systemVersion = Get-ComputerInfo | Select-Object OSName, OSVersion, OsHardwareAbstractionLayer, OsBuildNumber, WindowsEditionId
         $windowsDrive = Get-WindowsDrive
         $jcAdmuTempPath = "$windowsDrive\Windows\Temp\JCADMU\"
         $jcAdmuLogFile = "$windowsDrive\Windows\Temp\jcAdmu.log"
@@ -1883,7 +1883,10 @@ Function Start-Migration {
         $AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signed.msi"
         $AGENT_INSTALLER_PATH = "$windowsDrive\windows\Temp\JCADMU\jcagent-msi-signed.msi"
         $AGENT_CONF_PATH = "$($AGENT_PATH)\Plugins\Contrib\jcagent.conf"
-        $admuVersion = '2.7.7'
+        $admuVersion = '2.7.8'
+
+        # Log Windows System Version Information
+        Write-ToLog -Message:("OSName: $($systemVersion.OSName), OSVersion: $($systemVersion.OSVersion), OSBuildNumber: $($systemVersion.OsBuildNumber), OSEdition: $($systemVersion.WindowsEditionId)")
 
         $script:AdminDebug = $AdminDebug
         $isForm = $PSCmdlet.ParameterSetName -eq "form"

--- a/jumpcloud-ADMU/Powershell/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Start-Migration.ps1
@@ -2875,7 +2875,7 @@ Function Start-Migration {
                                 $admuTracker.leaveDomain.pass = $true
                             } else {
                                 Write-ToLog -Message:('Unable to leave Hybrid Domain') -Level:('Warn')
-                                $admuTracker.leaveDomain.fail = $true
+                                # here we would typically fail migration but doing so would remove the system account
                             }
                         }
                         "LocalJoined" {
@@ -2886,7 +2886,7 @@ Function Start-Migration {
                                 $admuTracker.leaveDomain.pass = $true
                             } else {
                                 Write-ToLog -Message:('Unable to leave local domain') -Level:('Warn')
-                                $admuTracker.leaveDomain.fail = $true
+                                # here we would typically fail migration but doing so would remove the system account
                             }
                         }
                         "AzureADJoined" {
@@ -2907,7 +2907,7 @@ Function Start-Migration {
                                     $admuTracker.leaveDomain.pass = $true
                                 } else {
                                     Write-ToLog -Message:('Unable to leave Azure AD domain') -Level:('Warn')
-                                    $admuTracker.leaveDomain.fail = $true
+                                    # here we would typically fail migration but doing so would remove the system account
                                 }
 
                             }


### PR DESCRIPTION
## Issues
* [CUT-4310](https://jumpcloud.atlassian.net/browse/CUT-4310) - CUT-4310 Add Windows OS Version info to Log
* [CUT-4354](https://jumpcloud.atlassian.net/browse/CUT-4354) - Leave Domain failure should not affect overall migration status
## What does this solve?

- Add Windows OS version information to `jcAdmu.log`
- When the leave domain step failed, the ADMU would consider this a failure of the entire migration and attempt to revert the newly create local user. However at this stage of migration, if that occurred, the account being migrated was removed. This release addresses this issue by removing the failure status when the "leave domain" step is not successful. 

## Is there anything particularly tricky?
n/a
## How should this be tested?
1. Run this version of ADMU
2. Migrate a user
3. View Log and check that Windows OS Version info is in the log 

![image](https://github.com/user-attachments/assets/6d3c680b-569d-4a04-b767-e9d20d547fb1)


[CUT-4310]: https://jumpcloud.atlassian.net/browse/CUT-4310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CUT-4354]: https://jumpcloud.atlassian.net/browse/CUT-4354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ