### PR TITLE
Folder Redirection Enhancement

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,3 +1,16 @@
+## 2.7.15
+
+Release Date: March 18, 2025
+
+#### RELEASE NOTES
+
+```
+This release enhances user directory redirection validation. Migrations now proceed correctly when user shell folders are redirected to OneDrive, Google Drive, and other local paths.
+```
+
+#### BUG FIXES:
+N/A
+
 ## 2.7.14
 
 Release Date: March 12, 2025

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,6 +1,6 @@
 ## 2.7.15
 
-Release Date: March 18, 2025
+Release Date: March 17, 2025
 
 #### RELEASE NOTES
 

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,6 +1,6 @@
 ## 2.7.15
 
-Release Date: March 17, 2025
+Release Date: March 18, 2025
 
 #### RELEASE NOTES
 

--- a/jumpcloud-ADMU/Powershell/Private/DisplayForms/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/DisplayForms/Form.ps1
@@ -33,7 +33,7 @@ Function Show-SelectionForm {
 <Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="JumpCloud ADMU 2.7.14"
+        Title="JumpCloud ADMU 2.7.15"
         WindowStyle="SingleBorderWindow"
         ResizeMode="NoResize"
         Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" ScrollViewer.HorizontalScrollBarVisibility="Visible" Width="1020" Height="590">

--- a/jumpcloud-ADMU/Powershell/Private/DisplayForms/ProgressForm.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/DisplayForms/ProgressForm.ps1
@@ -22,7 +22,7 @@ function New-ProgressForm {
     <Window
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Name="Window" Title="JumpCloud ADMU 2.7.14"
+    Name="Window" Title="JumpCloud ADMU 2.7.15"
     WindowStyle="SingleBorderWindow"
     ResizeMode="NoResize"
     Background="White" Width="720" Height="550  ">

--- a/jumpcloud-ADMU/Powershell/Private/UserIdentification/Test-UserFolderRedirect.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/UserIdentification/Test-UserFolderRedirect.ps1
@@ -56,7 +56,7 @@ function Test-UserFolderRedirect {
                 }
                 # Get the registry value for the user folder
                 $folderRegKeyValue = (Get-Item -path $fullPath ).GetValue($folderRegKey , '', 'DoNotExpandEnvironmentNames')
-                $defaultRegFolder = "%USERPROFILE%\$userFolder"
+                #$defaultRegFolder = "%USERPROFILE%\$userFolder"
                 # If the registry value does not match the default path, set redirectedDirectory to true and log the error
                 $regex = '^\\\\[a-zA-Z0-9.-]+\\[a-zA-Z0-9._-]+(\\[a-zA-Z0-9._-]+)*$' # regex for network paths ie \\server\share\folder, \\server.example.com\share\folder
                 if ($folderRegKeyValue -match $regex) {

--- a/jumpcloud-ADMU/Powershell/Private/UserIdentification/Test-UserFolderRedirect.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/UserIdentification/Test-UserFolderRedirect.ps1
@@ -58,11 +58,12 @@ function Test-UserFolderRedirect {
                 $folderRegKeyValue = (Get-Item -path $fullPath ).GetValue($folderRegKey , '', 'DoNotExpandEnvironmentNames')
                 $defaultRegFolder = "%USERPROFILE%\$userFolder"
                 # If the registry value does not match the default path, set redirectedDirectory to true and log the error
-                if ($folderRegKeyValue -ne $defaultRegFolder) {
-                    Write-ToLog -Message:("$($userFolder) path value: $($folderRegKeyValue) does not match default path  - $($defaultRegFolder)") -Level warn
+                $regex = '^\\\\[a-zA-Z0-9.-]+\\[a-zA-Z0-9._-]+(\\[a-zA-Z0-9._-]+)*$' # regex for network paths ie \\server\share\folder, \\server.example.com\share\folder
+                if ($folderRegKeyValue -match $regex) {
+                    Write-ToLog -Message:("$($userFolder) path value: $($folderRegKeyValue) is a network path (IP or Domain). Migration NOT allowed.") -Level warn
                     $redirectedDirectory = $true
                 } else {
-                    Write-ToLog -Message:("User Shell Folder: $($userFolder) is default")
+                    Write-ToLog -Message:("$($userFolder) path value: $($folderRegKeyValue). Migration allowed.")
                 }
             }
         } else {

--- a/jumpcloud-ADMU/Powershell/Public/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Migration.ps1
@@ -34,7 +34,7 @@ Function Start-Migration {
         $AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signed.msi"
         $AGENT_INSTALLER_PATH = "$windowsDrive\windows\Temp\JCADMU\jcagent-msi-signed.msi"
         $AGENT_CONF_PATH = "$($AGENT_PATH)\Plugins\Contrib\jcagent.conf"
-        $admuVersion = '2.7.14'
+        $admuVersion = '2.7.15'
         # Log Windows System Version Information
         Write-ToLog -Message:("OSName: $($systemVersion.OSName), OSVersion: $($systemVersion.OSVersion), OSBuildNumber: $($systemVersion.OsBuildNumber), OSEdition: $($systemVersion.WindowsEditionId)")
 

--- a/jumpcloud-ADMU/Powershell/Tests/Private/UserIdentification/Test-UserFolderRedirect.Acceptance.Tests.ps1
+++ b/jumpcloud-ADMU/Powershell/Tests/Private/UserIdentification/Test-UserFolderRedirect.Acceptance.Tests.ps1
@@ -41,6 +41,7 @@ Describe "Test-UserFolderRedirect Acceptance Tests" -Tag "Acceptance" {
             $userSid = Test-UsernameOrSID -usernameOrSid $newUser
             # Load the registry hive for the user and add _admu after the sid
             REG LOAD HKU\$($userSid)_admu "C:\Users\$newUser\NTUSER.DAT" *>&1
+            $folderPath = "HKEY_USERS:\$($userSid)_admu\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders"
         }
         # Test for Test-UserFolderRedirect should be default values
         It 'Test-UserFolderRedirect - Default values' {
@@ -50,16 +51,72 @@ Describe "Test-UserFolderRedirect Acceptance Tests" -Tag "Acceptance" {
         # Test for Test-UserFolderRedirect with one of the folder redirect values changed
         It 'Test-UserFolderRedirect - One value changed' {
             # Change the value of the folder Desktop to a different value
-            $folderPath = "HKEY_USERS:\$($userSid)_admu\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders"
+            Write-Output "Changing the value of the folder Desktop to a different value $($folderPath)"
             Set-ItemProperty -Path $folderpath -Name Desktop -Value "\\server\share\desktop"
+            # Validate that the folder has changed
+            (Get-ItemProperty -Path $folderpath).Desktop | Should -Be "\\server\share\desktop"
             Test-UserFolderRedirect -UserSid $userSid | Should -Be $true
             # Change the value of the folder Desktop back to the default value
             Set-ItemProperty -Path $folderpath -Name Desktop -Value "%USERPROFILE%\Desktop"
-
         }
         # Test for Invalid SID or Invalid User Shell Folder
         It 'Test-UserFolderRedirect - Invalid SID or Invalid User Shell Folder' {
             Test-UserFolderRedirect -UserSid "Invalid-3361044348-30300820-1001" | Should -be $true
+        }
+        # Test for IP Path
+        It 'Test-UserFolderRedirect - IP Path' {
+            # Change the value of the folder Documents to an IP path
+            Set-ItemProperty -Path $folderpath -Name "My Music" -Value "\\192.168.1.10\SharedFolder\Music"
+            # Validate that the folder has changed
+            (Get-ItemProperty -Path $folderpath)."My Music" | Should -Be "\\192.168.1.10\SharedFolder\Music"
+            # Test path
+            Write-Host $userSid
+            Test-UserFolderRedirect -UserSid $userSid | Should -Be $true
+            # Change the value of the folder Documents back to the default value
+            Set-ItemProperty -Path $folderpath -Name "My Music" -Value "%USERPROFILE%\Music"
+        }
+        # Test for Domain Path
+        It 'Test-UserFolderRedirect - Domain Path' {
+            # Change the value of the folder Documents to a domain path
+            Set-ItemProperty -Path $folderpath -Name Desktop -Value "\\domain.local\SharedFolder\Desktop"
+            # Validate that the folder has changed
+            (Get-ItemProperty -Path $folderpath).Desktop | Should -Be "\\domain.local\SharedFolder\Desktop"
+            Test-UserFolderRedirect -UserSid $userSid | Should -Be $true
+            # Change the value of the folder Desktop back to the default value
+            Set-ItemProperty -Path $folderpath -Name Desktop -Value "%USERPROFILE%\Desktop"
+        }
+        It 'Test-UserFolderRedirect - My Drive (GDrive)' {
+            # Change the value of the folder Documents to a Google Drive path/different drive letter
+            # Note: This is a test for a Google Drive path, but it can be adapted for any other drive letter
+            Set-ItemProperty -Path $folderpath -Name "{374DE290-123F-4565-9164-39C4925E467B}" -Value "G:\My Drive\Downloads" # Using the Downloads ID
+            # Validate that the folder has changed
+            (Get-ItemProperty -Path $folderpath)."{374DE290-123F-4565-9164-39C4925E467B}" | Should -Be "G:\My Drive\Downloads"
+            # Test path
+            Test-UserFolderRedirect -UserSid $userSid | Should -Be $false
+
+            Set-ItemProperty -Path $folderpath -Name "{374DE290-123F-4565-9164-39C4925E467B}" -Value "%USERPROFILE%\Downloads"
+        }
+        # Test for OneDrive in the path
+        It 'Test-UserFolderRedirect - OneDrive' {
+            # Change the value of the folder Documents to a OneDrive path
+            Set-ItemProperty -Path $folderpath -Name Documents -Value "C:\Users\$newUser\OneDrive\Documents"
+            # Validate that the folder has changed
+            (Get-ItemProperty -Path $folderpath).Documents | Should -Be "C:\Users\$newUser\OneDrive\Documents"
+
+            # Test path
+            Test-UserFolderRedirect -UserSid $userSid | Should -Be $false
+
+            # Set the folder values back to default
+            Set-ItemProperty -Path $folderpath -Name Documents -Value "%USERPROFILE%\Documents"
+        }
+        # Test for a default value for the folder path
+        It 'Test-UserFolderRedirect - Default value for the folder path' {
+            # Change the value of the folder Documents to a default value
+            Set-ItemProperty -Path $folderpath -Name Documents -Value "%USERPROFILE%\Documents"
+            # Validate that the folder has changed
+            (Get-ItemProperty -Path $folderpath).Documents | Should -Be "%USERPROFILE%\Documents"
+            # Test path
+            Test-UserFolderRedirect -UserSid $userSid | Should -Be $false
         }
     }
 }


### PR DESCRIPTION
## Issues
* [CUT-4671](https://jumpcloud.atlassian.net/browse/4671) - CUT-4671-local-redirected-shell-folders-migration

## What does this solve?
Fixes issue with migrating users with locally redirected user shell folders such as OneDrive (`C:Users\Test\OneDrive\Desktop`) or Google Drive (`G:\My Drive\Desktop`) paths
## Is there anything particularly tricky?
n/a
## How should this be tested?
**Invalid Test:**
1. Redirect one of the user to be migrated folder (Desktop, Documents, or Downloads ({374DE290-123F-4565-9164-39C4925E467B})) to with an invalid network path
ex. `\\192.168.1.10\SharedFolder\Documents` or `\\server\share\Desktop` or `\\server.example.com\Downloads`

User shell folders are located in: `HKEY_USERS:\USERSID\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders`
2. Run ADMU migration, migration should not continue.
![image](https://github.com/user-attachments/assets/5541408a-c738-47be-a20e-70668001df7b)


**Valid**
1. Set the values of (Desktop, Documents, or Downloads ({374DE290-123F-4565-9164-39C4925E467B})) to:
ex. C:\Users\Test\OneDrive\Desktop or G:\My Drive\Desktop
2. Migration should continue and succeed
![image](https://github.com/user-attachments/assets/93d6236e-dec5-496a-9704-1d8371e3f406)

[CUT-4671]: https://jumpcloud.atlassian.net/browse/CUT-4671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ