### PR TITLE
Cut 5045 ADMU Revert Bug (Profiles with .bak)

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,6 +1,6 @@
 ## 2.12.2
 
-Release Date: January 26, 2026
+Release Date: January 27, 2026
 
 #### RELEASE NOTES
 

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,4 +1,4 @@
-## 2.12.0
+## 2.13.0
 
 Release Date: January 21, 2026
 

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -16,6 +16,20 @@ Additional method for migration reversion by considering the .bak suffix in the 
 
 Test added to validate new features and existing functionality.
 
+## 2.12.1
+
+Release Date: January 20, 2026
+
+#### RELEASE NOTES
+
+```
+Added Bug fix for temp user directory renaming
+```
+
+#### BUG FIXES:
+
+- Resolved an issue where renaming a created temp profile fails and freezes the migration
+
 ## 2.12.0
 
 Release Date: January 15, 2026

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,5 +1,23 @@
 ## 2.12.0
 
+Release Date: January 21, 2026
+
+#### RELEASE NOTES
+
+```
+This release includes the option perform the migration reversion successfully even if the registry profilelist is renamed with .bak suffix.
+```
+
+#### FEATURES:
+
+Additional method for migration reversion by considering the .bak suffix in the reg profile path.
+
+#### IMPROVEMENTS:
+
+Test added to validate new features and existing functionality.
+
+## 2.12.0
+
 Release Date: January 15, 2026
 
 #### RELEASE NOTES

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,6 +1,6 @@
-## 2.13.0
+## 2.12.2
 
-Release Date: January 21, 2026
+Release Date: January 26, 2026
 
 #### RELEASE NOTES
 

--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,6 +1,6 @@
 ## 2.12.2
 
-Release Date: January 27, 2026
+Release Date: January 28, 2026
 
 #### RELEASE NOTES
 

--- a/jumpcloud-ADMU/JumpCloud.ADMU.psd1
+++ b/jumpcloud-ADMU/JumpCloud.ADMU.psd1
@@ -8,125 +8,125 @@
 
 @{
 
-# Script module or binary module file associated with this manifest.
-RootModule = 'JumpCloud.ADMU.psm1'
+    # Script module or binary module file associated with this manifest.
+    RootModule        = 'JumpCloud.ADMU.psm1'
 
-# Version number of this module.
-ModuleVersion = '2.12.0'
+    # Version number of this module.
+    ModuleVersion     = '2.12.2'
 
-# Supported PSEditions
-# CompatiblePSEditions = @()
+    # Supported PSEditions
+    # CompatiblePSEditions = @()
 
-# ID used to uniquely identify this module
-GUID = '8354fb8a-af52-4db9-9882-a903063751a5'
+    # ID used to uniquely identify this module
+    GUID              = '8354fb8a-af52-4db9-9882-a903063751a5'
 
-# Author of this module
-Author = 'JumpCloud Customer Tools Team'
+    # Author of this module
+    Author            = 'JumpCloud Customer Tools Team'
 
-# Company or vendor of this module
-CompanyName = 'JumpCloud'
+    # Company or vendor of this module
+    CompanyName       = 'JumpCloud'
 
-# Copyright statement for this module
-Copyright = '(c) JumpCloud. All rights reserved.'
+    # Copyright statement for this module
+    Copyright         = '(c) JumpCloud. All rights reserved.'
 
-# Description of the functionality provided by this module
-Description = 'Powershell Module to run JumpCloud Active Directory Migration Utility.'
+    # Description of the functionality provided by this module
+    Description       = 'Powershell Module to run JumpCloud Active Directory Migration Utility.'
 
-# Minimum version of the PowerShell engine required by this module
-# PowerShellVersion = ''
+    # Minimum version of the PowerShell engine required by this module
+    # PowerShellVersion = ''
 
-# Name of the PowerShell host required by this module
-# PowerShellHostName = ''
+    # Name of the PowerShell host required by this module
+    # PowerShellHostName = ''
 
-# Minimum version of the PowerShell host required by this module
-# PowerShellHostVersion = ''
+    # Minimum version of the PowerShell host required by this module
+    # PowerShellHostVersion = ''
 
-# Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# DotNetFrameworkVersion = ''
+    # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # DotNetFrameworkVersion = ''
 
-# Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# ClrVersion = ''
+    # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # ClrVersion = ''
 
-# Processor architecture (None, X86, Amd64) required by this module
-# ProcessorArchitecture = ''
+    # Processor architecture (None, X86, Amd64) required by this module
+    # ProcessorArchitecture = ''
 
-# Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
+    # Modules that must be imported into the global environment prior to importing this module
+    # RequiredModules = @()
 
-# Assemblies that must be loaded prior to importing this module
-# RequiredAssemblies = @()
+    # Assemblies that must be loaded prior to importing this module
+    # RequiredAssemblies = @()
 
-# Script files (.ps1) that are run in the caller's environment prior to importing this module.
-# ScriptsToProcess = @()
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+    # ScriptsToProcess = @()
 
-# Type files (.ps1xml) to be loaded when importing this module
-# TypesToProcess = @()
+    # Type files (.ps1xml) to be loaded when importing this module
+    # TypesToProcess = @()
 
-# Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
+    # Format files (.ps1xml) to be loaded when importing this module
+    # FormatsToProcess = @()
 
-# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-# NestedModules = @()
+    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+    # NestedModules = @()
 
-# Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Start-Migration', 'Start-Reversion'
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport = 'Start-Migration', 'Start-Reversion'
 
-# Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = '*'
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport   = '*'
 
-# Variables to export from this module
-VariablesToExport = '*'
+    # Variables to export from this module
+    VariablesToExport = '*'
 
-# Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = '*'
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport   = '*'
 
-# DSC resources to export from this module
-# DscResourcesToExport = @()
+    # DSC resources to export from this module
+    # DscResourcesToExport = @()
 
-# List of all modules packaged with this module
-# ModuleList = @()
+    # List of all modules packaged with this module
+    # ModuleList = @()
 
-# List of all files packaged with this module
-# FileList = @()
+    # List of all files packaged with this module
+    # FileList = @()
 
-# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
-PrivateData = @{
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData       = @{
 
-    PSData = @{
+        PSData = @{
 
-        # Tags applied to this module. These help with module discovery in online galleries.
-        # Tags = @()
+            # Tags applied to this module. These help with module discovery in online galleries.
+            # Tags = @()
 
-        # A URL to the license for this module.
-        # LicenseUri = ''
+            # A URL to the license for this module.
+            # LicenseUri = ''
 
-        # A URL to the main website for this project.
-        # ProjectUri = ''
+            # A URL to the main website for this project.
+            # ProjectUri = ''
 
-        # A URL to an icon representing this module.
-        # IconUri = ''
+            # A URL to an icon representing this module.
+            # IconUri = ''
 
-        # ReleaseNotes of this module
-        # ReleaseNotes = ''
+            # ReleaseNotes of this module
+            # ReleaseNotes = ''
 
-        # Prerelease string of this module
-        # Prerelease = ''
+            # Prerelease string of this module
+            # Prerelease = ''
 
-        # Flag to indicate whether the module requires explicit user acceptance for install/update/save
-        # RequireLicenseAcceptance = $false
+            # Flag to indicate whether the module requires explicit user acceptance for install/update/save
+            # RequireLicenseAcceptance = $false
 
-        # External dependent modules of this module
-        # ExternalModuleDependencies = @()
+            # External dependent modules of this module
+            # ExternalModuleDependencies = @()
 
-    } # End of PSData hashtable
+        } # End of PSData hashtable
 
-} # End of PrivateData hashtable
+    } # End of PrivateData hashtable
 
-# HelpInfo URI of this module
-# HelpInfoURI = ''
+    # HelpInfo URI of this module
+    # HelpInfoURI = ''
 
-# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-# DefaultCommandPrefix = ''
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    # DefaultCommandPrefix = ''
 
 }
 

--- a/jumpcloud-ADMU/Powershell/Private/DisplayForms/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/DisplayForms/Form.ps1
@@ -33,7 +33,7 @@ Function Show-SelectionForm {
 <Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="JumpCloud ADMU 2.12.0"
+        Title="JumpCloud ADMU 2.12.2"
         WindowStyle="SingleBorderWindow"
         ResizeMode="NoResize"
         Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" ScrollViewer.HorizontalScrollBarVisibility="Visible" Width="1020" Height="590">

--- a/jumpcloud-ADMU/Powershell/Private/DisplayForms/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/DisplayForms/Form.ps1
@@ -552,15 +552,17 @@ Function Show-SelectionForm {
     $migratedUsers = @()
 
     foreach ($listItem in $profileList) {
-        $sidPattern = "^S-\d-\d+-(\d+-){1,14}\d+$"
-        $isValidFormat = [regex]::IsMatch($($listItem.PSChildName), $sidPattern);
+        $sidPattern = "^S-\d-\d+-(\d+-){1,14}\d+(?:\.bak)?$"
+        $rawSid = $listItem.PSChildName
+        $normalizedSid = $rawSid -replace '\.bak$', ''
+        $isValidFormat = [regex]::IsMatch($normalizedSid, $sidPattern);
 
         if ($isValidFormat) {
-            # Create the Object first
+            # Normalize SIDs stored as .bak keys so lookups and display names work consistently
             $userObj = [PSCustomObject]@{
-                Name              = Convert-SecurityIdentifier $listItem.PSChildName
+                Name              = Convert-SecurityIdentifier $normalizedSid
                 LocalPath         = $listItem.ProfileImagePath
-                SID               = $listItem.PSChildName
+                SID               = $normalizedSid
                 IsLocalAdmin      = $null
                 LocalProfileSize  = $null
                 Loaded            = $null

--- a/jumpcloud-ADMU/Powershell/Private/DisplayForms/ProgressForm.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/DisplayForms/ProgressForm.ps1
@@ -22,7 +22,7 @@ function New-ProgressForm {
     <Window
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Name="Window" Title="JumpCloud ADMU 2.12.1"
+    Name="Window" Title="JumpCloud ADMU 2.12.2"
     WindowStyle="SingleBorderWindow"
     ResizeMode="NoResize"
     Background="White" Width="720" Height="550  ">

--- a/jumpcloud-ADMU/Powershell/Private/RegistryKey/Confirm-ProfileSidAssociation.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/RegistryKey/Confirm-ProfileSidAssociation.ps1
@@ -13,7 +13,7 @@ function Confirm-ProfileSidAssociation {
     )
     try {
         Write-ToLog -Message "Validating profile path association with SID: $UserSID" -Level Verbose -Step "Revert-Migration"
-        $profileRegistryKey = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$UserSID"
+        $profileRegistryKey = (Get-ProfileRegistryPath -UserSID $UserSID).ResolvedPath
         $regProfilePath = (Get-ItemProperty -Path $profileRegistryKey -Name "ProfileImagePath" -ErrorAction Stop).ProfileImagePath
 
         # Remove the .ADMU suffix

--- a/jumpcloud-ADMU/Powershell/Private/RegistryKey/Get-ProfileRegistryPath.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/RegistryKey/Get-ProfileRegistryPath.ps1
@@ -1,0 +1,28 @@
+function Get-ProfileRegistryPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$UserSID
+    )
+
+    $basePath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$UserSID"
+    $resolvedPath = $null
+
+    if (Test-Path -Path $basePath) {
+        $resolvedPath = $basePath
+    } else {
+        $bakPath = "$basePath.bak"
+        if (Test-Path -Path $bakPath) {
+            $resolvedPath = $bakPath
+            Write-ToLog -Message "Resolved profile registry path via .bak entry for SID: $UserSID" -Level Verbose -Step "RegistryLookup"
+        }
+    }
+
+    if (-not $resolvedPath) {
+        throw "Profile registry path not found for SID: $UserSID"
+    }
+
+    return [PSCustomObject]@{
+        ResolvedPath = $resolvedPath
+    }
+}

--- a/jumpcloud-ADMU/Powershell/Public/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Migration.ps1
@@ -175,7 +175,7 @@ function Start-Migration {
         $AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signed.msi"
         $AGENT_INSTALLER_PATH = "$windowsDrive\windows\Temp\JCADMU\jcagent-msi-signed.msi"
         $AGENT_CONF_PATH = "$($AGENT_PATH)\Plugins\Contrib\jcagent.conf"
-        $admuVersion = "2.12.1"
+        $admuVersion = "2.12.2"
         $script:JumpCloudUserID = $JumpCloudUserID
         $script:AdminDebug = $AdminDebug
         $isForm = $PSCmdlet.ParameterSetName -eq "form"

--- a/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
@@ -210,7 +210,7 @@ function Start-Reversion {
                 if ($originalRegistryProfileImagePath -match '\\TEMP$' -and (Test-Path -LiteralPath $profileRegistryBakPath)) {
                     try {
                         $bakProfileImagePath = (Get-ItemProperty -Path $profileRegistryBakPath -Name "ProfileImagePath" -ErrorAction Stop).ProfileImagePath
-                        if ($TargetProfileImagePath -eq $bakProfileImagePath) {
+                        if (($bakProfileImagePath -replace $admuPathPattern, '') -eq $TargetProfileImagePath) {
                             Write-ToLog -Message "Target profile path matches .bak registry entry. Skipping validation since base key points to TEMP." -Level Verbose -Step "Revert-Migration"
                             $skipValidation = $true
                         }

--- a/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
@@ -523,10 +523,14 @@ function Start-Reversion {
                             Rename-Item -LiteralPath $profileRegistryBakPath -NewName (Split-Path -Leaf $basePath) -Force -ErrorAction Stop
                             Write-ToLog -Message "Successfully renamed registry entry to $basePath" -Level Info -Step "Revert-Migration"
                         } else {
-                            # Safe to remove the .bak entry if it's separate from the active profile path
-                            Write-ToLog -Message "Removing registry entry $profileRegistryBakPath" -Level Info -Step "Revert-Migration"
-                            Remove-Item -LiteralPath $profileRegistryBakPath -Recurse -Force -ErrorAction Stop
-                            Write-ToLog -Message "Successfully removed registry entry $profileRegistryBakPath" -Level Info -Step "Revert-Migration"
+                            # Safe to remove the .bak entry if it's separate from the active profile path and registry update succeeded
+                            if ($revertResult.RegistryUpdated) {
+                                Write-ToLog -Message "Removing registry entry $profileRegistryBakPath" -Level Info -Step "Revert-Migration"
+                                Remove-Item -LiteralPath $profileRegistryBakPath -Recurse -Force -ErrorAction Stop
+                                Write-ToLog -Message "Successfully removed registry entry $profileRegistryBakPath" -Level Info -Step "Revert-Migration"
+                            } else {
+                                Write-ToLog -Message "Preserving registry entry $profileRegistryBakPath as recovery reference since ProfileImagePath update failed" -Level Warning -Step "Revert-Migration"
+                            }
                         }
                     } catch {
                         $errorMsg = "Failed to process registry entry $profileRegistryBakPath : $($_.Exception.Message)"

--- a/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
@@ -152,8 +152,7 @@ function Start-Reversion {
             Write-ToProgress -form $form -Status "revertInit" -ProgressBar $ProgressBar -ProfileSize $profileSize -LocalPath $TargetProfileImagePath -StatusMap $revertMessageMap
 
             # Get profile information from registry for validation
-            $profileRegistryPath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$UserSID"
-
+            $profileRegistryPath = (Get-ProfileRegistryPath -UserSID $UserSID).ResolvedPath
             # Casing fixed to 'revertValidateProfilePath', removed -StatusType, added -StatusMap
             Write-ToProgress -form $form -Status "revertValidateProfilePath" -ProgressBar $ProgressBar -StatusMap $revertMessageMap
             if (-not (Test-Path $profileRegistryPath)) {
@@ -171,7 +170,6 @@ function Start-Reversion {
             }
 
             Write-ToLog -Message "Confirmed .ADMU migration profile detected in registry" -Level Verbose -Step "Revert-Migration"
-
             # Determine which profile path to use
             if ($TargetProfileImagePath) {
                 Write-ToLog -Message "Using provided target profile path: $TargetProfileImagePath" -Level Info -Step "Revert-Migration"
@@ -186,7 +184,10 @@ function Start-Reversion {
             } else {
                 # Use registry path, remove .ADMU suffix
                 $profileImagePath = $registryProfileImagePath -replace $admuPathPattern, ''
+
                 $sidValidation = Confirm-ProfileSidAssociation -ProfilePath $profileImagePath -UserSID $UserSID
+                Write-Host "Test $sidValidation"
+
                 if (-not $sidValidation.IsValid) {
                     throw "Registry profile path validation failed: $($sidValidation.Reason)"
                 }

--- a/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
@@ -172,11 +172,8 @@ function Start-Reversion {
 
             # Validate this is an ADMU migrated profile by checking registry path
             if ($registryProfileImagePath -notmatch $admuPathPattern) {
-                if ($registryProfileImagePath -match '\\TEMP$') {
-                    Write-ToLog -Message "Registry profile path resolved to temporary profile: $registryProfileImagePath" -Level Warning -Step "Revert-Migration"
-                } else {
-                    throw "Registry profile path does not contain .ADMU suffix. This does not appear to be a migrated profile: $registryProfileImagePath"
-                }
+                throw "Registry profile path does not contain .ADMU suffix. This does not appear to be a migrated profile: $registryProfileImagePath"
+
             } else {
                 Write-ToLog -Message "Confirmed .ADMU migration profile detected in registry" -Level Verbose -Step "Revert-Migration"
             }

--- a/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
@@ -545,10 +545,14 @@ function Start-Reversion {
                         # Check if the resolved profile registry path is the .bak path
                         if ($profileRegistryPath -eq $profileRegistryBakPath) {
                             # If we updated the .bak key, rename it to the base name instead of deleting it
-                            $basePath = $profileRegistryBasePath
-                            Write-ToLog -Message "Renaming registry entry from $profileRegistryBakPath to $basePath" -Level Info -Step "Revert-Migration"
-                            Rename-Item -LiteralPath $profileRegistryBakPath -NewName (Split-Path -Leaf $basePath) -Force -ErrorAction Stop
-                            Write-ToLog -Message "Successfully renamed registry entry to $basePath" -Level Info -Step "Revert-Migration"
+                            if ($revertResult.RegistryUpdated) {
+                                $basePath = $profileRegistryBasePath
+                                Write-ToLog -Message "Renaming registry entry from $profileRegistryBakPath to $basePath" -Level Info -Step "Revert-Migration"
+                                Rename-Item -LiteralPath $profileRegistryBakPath -NewName (Split-Path -Leaf $basePath) -Force -ErrorAction Stop
+                                Write-ToLog -Message "Successfully renamed registry entry to $basePath" -Level Info -Step "Revert-Migration"
+                            } else {
+                                Write-ToLog -Message "Preserving registry entry $profileRegistryBakPath as recovery reference since ProfileImagePath update failed" -Level Warning -Step "Revert-Migration"
+                            }
                         } else {
                             # Safe to remove the .bak entry if it's separate from the active profile path and registry update succeeded
                             if ($revertResult.RegistryUpdated) {

--- a/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
@@ -158,9 +158,6 @@ function Start-Reversion {
             $profileRegistryPath = (Get-ProfileRegistryPath -UserSID $UserSID).ResolvedPath
             # Casing fixed to 'revertValidateProfilePath', removed -StatusType, added -StatusMap
             Write-ToProgress -form $form -Status "revertValidateProfilePath" -ProgressBar $ProgressBar -StatusMap $revertMessageMap
-            if (-not (Test-Path $profileRegistryPath)) {
-                throw "Profile registry path not found for SID: $UserSID"
-            }
 
             $profileRegistryBasePath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$UserSID"
             $profileRegistryBakPath = "$profileRegistryBasePath.bak"
@@ -177,9 +174,9 @@ function Start-Reversion {
                 } else {
                     throw "Registry profile path does not contain .ADMU suffix. This does not appear to be a migrated profile: $registryProfileImagePath"
                 }
+            } else {
+                Write-ToLog -Message "Confirmed .ADMU migration profile detected in registry" -Level Verbose -Step "Revert-Migration"
             }
-
-            Write-ToLog -Message "Confirmed .ADMU migration profile detected in registry" -Level Verbose -Step "Revert-Migration"
             # Determine which profile path to use
             if ($TargetProfileImagePath) {
                 Write-ToLog -Message "Using provided target profile path: $TargetProfileImagePath" -Level Info -Step "Revert-Migration"

--- a/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
@@ -532,7 +532,6 @@ function Start-Reversion {
                         $errorMsg = "Failed to process registry entry $profileRegistryBakPath : $($_.Exception.Message)"
                         Write-ToLog -Message $errorMsg -Level Error -Step "Revert-Migration"
                         $revertResult.Errors += $errorMsg
-                        $revertResult.RegistryUpdated = $false
                     }
                 } else {
                     Write-ToLog -Message "No SID.bak registry entry found for SID: $UserSID" -Level Verbose -Step "Revert-Migration"

--- a/jumpcloud-ADMU/Powershell/Tests/Private/RegistryKey/Get-ProfileRegistryPath.Acceptance.Tests.ps1
+++ b/jumpcloud-ADMU/Powershell/Tests/Private/RegistryKey/Get-ProfileRegistryPath.Acceptance.Tests.ps1
@@ -1,0 +1,78 @@
+#Write tests for Get-ProfileRegistryPath function
+
+Describe "Get-ProfileRegistryPath Acceptance Tests" {
+
+    BeforeAll {
+        # Import the module
+        $modulePath = Join-Path $PSScriptRoot "..\..\..\..\JumpCloud.ADMU.psd1"
+        Import-Module $modulePath -Force
+
+        # Get a valid SID from the current user
+        $currentIdentity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+        $testSID = $currentIdentity.User.Value
+    }
+
+    Context "When testing with current user SID" {
+
+        It "Should return a valid registry path for current user SID" {
+            # Check if the registry key exists
+            $basePath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$testSID"
+            $bakPath = "$basePath.bak"
+
+            $pathExists = (Test-Path -Path $basePath) -or (Test-Path -Path $bakPath)
+
+            if ($pathExists) {
+                $result = Get-ProfileRegistryPath -UserSID $testSID
+
+                $result | Should -Not -BeNullOrEmpty
+                $result.ResolvedPath | Should -Match "^HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\$testSID(\.bak)?$"
+                $result.PSObject.Properties.Name | Should -Contain "ResolvedPath"
+            } else {
+                Set-ItResult -Skipped -Because "Registry path does not exist for current user SID on this system"
+            }
+        }
+
+        It "Should prefer base path over .bak path when both exist" {
+            $basePath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$testSID"
+            $bakPath = "$basePath.bak"
+
+            if ((Test-Path -Path $basePath) -and (Test-Path -Path $bakPath)) {
+                $result = Get-ProfileRegistryPath -UserSID $testSID
+
+                $result.ResolvedPath | Should -Be $basePath
+            } else {
+                Set-ItResult -Skipped -Because "Both base and .bak registry paths do not exist for current user SID"
+            }
+        }
+
+        It "Should return .bak path when base path does not exist" {
+            $basePath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$testSID"
+            $bakPath = "$basePath.bak"
+
+            if (-not (Test-Path -Path $basePath) -and (Test-Path -Path $bakPath)) {
+                $result = Get-ProfileRegistryPath -UserSID $testSID
+
+                $result.ResolvedPath | Should -Be $bakPath
+            } else {
+                Set-ItResult -Skipped -Because "Base path exists or .bak path does not exist for current user SID"
+            }
+        }
+    }
+
+    Context "When testing with invalid SID" {
+
+        It "Should throw an exception for non-existent SID" {
+            $invalidSID = "S-1-5-21-1234567890-1234567890-1234567890-9999"
+
+            $basePath = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$invalidSID"
+            $bakPath = "$basePath.bak"
+
+            # Ensure they don't exist
+            if (-not (Test-Path -Path $basePath) -and -not (Test-Path -Path $bakPath)) {
+                { Get-ProfileRegistryPath -UserSID $invalidSID } | Should -Throw "Profile registry path not found for SID: $invalidSID"
+            } else {
+                Set-ItResult -Skipped -Because "Registry paths unexpectedly exist for invalid SID"
+            }
+        }
+    }
+}

--- a/jumpcloud-ADMU/Powershell/Tests/Public/Start-Reversion.Acceptance.Tests.ps1
+++ b/jumpcloud-ADMU/Powershell/Tests/Public/Start-Reversion.Acceptance.Tests.ps1
@@ -136,7 +136,7 @@ Describe "Start-Reversion Tests" -Tag "Migration Parameters" {
                         TargetProfileImagePath = "C:\Users\$userToMigrateFrom"
                     }
 
-                    $revertResult = Start-Reversion @reversionInput -ErrorAction Stop -Force
+                    $revertResult = Start-Reversion @reversionInput -ErrorAction SilentlyContinue -Force
                     $revertResult | Should -Not -BeNullOrEmpty
                     $revertResult.Success | Should -BeTrue
                     $revertResult.RegistryUpdated | Should -BeTrue


### PR DESCRIPTION
## Issues
* [CUT-5045](https://jumpcloud.atlassian.net/browse/CUT-5045) - ADMU Revert Bug (Profiles with .bak)

## What does this solve?
When reverting an account that has logged in with a temporary profile, Windows appends a .bak suffix to the user’s registry key under:

HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\{UserSID}

In this state, the start-reversion function failed during user restoration because it did not account for the .bak registry key, causing the reversion process to error and never complete.

This update adds handling for .bak profile registry entries, allowing the tool to correctly identify and restore the migrated user. As a result, account reversion now completes successfully even when a temporary profile was previously assigned.

## Is there anything particularly tricky?
NA

## How should this be tested?
1) Create or select a test user account.
2) Perform a standard migration for the user and confirm it completes successfully.
3) Locate the user’s SID under: HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList
4) Rename the user’s SID registry key to append .bak (e.g., {UserSID}.bak) to simulate a temporary profile condition.## Screenshots
5) Run the Start-Reversion function for the migrated user
6) Allow the reversion process to complete.

Start-Reversion correctly identifies the .bak registry entry as belonging to the target user. The user profile is restored successfully.

## Screenshots
NA

[CUT-5045]: https://jumpcloud.atlassian.net/browse/CUT-5045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds robust handling for Windows `.bak` profile registry entries during reversion.
> 
> - New `Get-ProfileRegistryPath` resolves `HKLM:\...\ProfileList\{SID}` or `{SID}.bak`; used by `Start-Reversion` and `Confirm-ProfileSidAssociation`
> - `Start-Reversion` accepts SIDs with `.bak`, normalizes SIDs, prefers `.bak` when base points to `TEMP`, adjusts validation/skip paths, and cleans up or renames `.bak` entries post-update
> - GUI `Form.ps1` normalizes `.bak` SIDs when listing users; progress/form titles updated to `2.12.2`; module version bumped
> - Tests: acceptance tests for `Get-ProfileRegistryPath` and `.bak` reversion flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e0bbe45c37a863c0c4cf8d68709bdbc30b45d5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->