### PR TITLE
Cut 5127 update read me

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -8,7 +8,7 @@ The JumpCloud Active Directory Migration Utility (ADMU) is designed to migrate A
 
 Check out the [Releases](https://github.com/TheJumpCloud/jumpcloud-ADMU/releases) page for the GUI and PowerShell tool downloads.
 
-Continue to [Getting Started](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Getting-Started) and the [Wiki](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki) for further information.
+Continue to the [Wiki](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki) for more information and documentation for remote migration scenarios.
 
 ### Have questions? feature request? issues?
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,15 +1,31 @@
 # JumpCloud Active Directory Migration Utility
 
-![admu-landging-image](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/images/ADMU-landing.png)
+![ADMU overview](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/images/ADMU-landing.png)
 
-The JumpCloud Active Directory Migration Utility (ADMU) is designed to migrate Active Directory or Azure Active Directory accounts to local account for subsequent JumpCloud takeover and management. Active Directory accounts on a system can not be directly taken over by the JumpCloud Agent. Those accounts must first be converted to a local account before the JumpCloud agent can take-over and manage that account on a given system. The ADMU aims to help admins automate the otherwise tedious process of account migration.
+The JumpCloud Active Directory Migration Utility (ADMU) migrates **Active Directory** or **Entra ID / Azure AD**–joined Windows users to **local accounts** so the [JumpCloud agent](https://jumpcloud.com/) can manage them. Domain accounts cannot be taken over directly by the agent; they must be converted to a local profile first. ADMU automates profile, registry, permissions, and optional domain-unbind / agent steps that would otherwise be manual.
 
-### Releases
+## Documentation
 
-Check out the [Releases](https://github.com/TheJumpCloud/jumpcloud-ADMU/releases) page for the GUI and PowerShell tool downloads.
+Detailed guides, limitations, and troubleshooting live in the **[Wiki](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki)**. Good starting points:
 
-Continue to the [Wiki](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki) for more information and documentation for remote migration scenarios.
+| Topic                                                  | Wiki                                                                                                                                                                  |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Planning and first run                                 | [Getting Started](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Getting-Started)                                                                                |
+| Tool Options + GUI                                     | [GUI Parameters](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/admu-gui)                                                                                        |
+| Known constraints (certs, credentials, defaults, etc.) | [Limitations](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Limitations-of-User-Account-Conversion)                                                             |
+| Logs and failures                                      | [Logging](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Logging), [Troubleshooting](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Troubleshooting-errors) |
+| Remote migration (CLI, JumpCloud Commands, bulk)       | [Invoke admu from JumpCloud Agent](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Invoke-admu-from-jcagent)                                                      |
 
-### Have questions? feature request? issues?
+## Releases
 
-Please use the GitHub issues tab, email [support@jumpcloud.com](support@jumpcloud.com) or the [feedback form](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/feedback-form).
+- **GUI and CLI:** Download the latest build from **[Releases](https://github.com/TheJumpCloud/jumpcloud-ADMU/releases)**. Each release includes **`gui_jcadmu.exe`** (interactive GUI and CLI in one binary) and **`uwp_jcadmu.exe`**, which migration deploys into the Windows directory to fix UWP Appx package issues.
+
+Only the `gui_jcadmu.exe` file is required for the ADMU, double click to run the GUI or pass parameters for scripted CLI use. The `uwp_jcadmu.exe` file is automatically downloaded and deployed into the Windows directory during migration to fix UWP Appx package issues.
+
+## Support
+
+Questions, bugs, and feature requests: **GitHub Issues** on this repository, [support@jumpcloud.com](mailto:support@jumpcloud.com), or the [feedback form](https://github.com/TheJumpCloud/jumpcloud-ADMU/wiki/Feedback-Form).
+
+## License
+
+This project is licensed under the [MIT License](./LICENSE).


### PR DESCRIPTION
## Issues
* [CUT-5127](https://jumpcloud.atlassian.net/browse/CUT-5127) - Update Readme

## What does this solve?

After updating wiki docs, the "getting started" page no longer exists, just updating the readme docs for ADMU to reflect that

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots

[CUT-5127]: https://jumpcloud.atlassian.net/browse/CUT-5127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no impact on runtime behavior; main risk is incorrect/outdated links.
> 
> **Overview**
> Updates `ReadMe.md` to refresh the project overview and reposition the README as an entry point to the Wiki, adding a quick-link table for key docs (getting started, GUI params, limitations, logging/troubleshooting, remote invocation).
> 
> Clarifies release artifacts and usage by documenting `gui_jcadmu.exe` vs `uwp_jcadmu.exe`, and adds explicit Support and License sections with corrected links/formatting (including the header image alt text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739d969563fc1ade9d97f21380365e65fbf32f91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->