### PR TITLE
ADMU usrClass Dat, Update if missing required permissions

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -5,10 +5,17 @@ Release Date: June 4, 2026
 #### RELEASE NOTES
 
 ```
-
 Patch release to address system context API signing failures on some devices when using
 systemContextBinding (client.key RSA private key import returned null, causing signature errors).
+
+Fixes an issue where UsrClass.dat hive file permissions could be incorrect after migration,
+causing the user to receive a temporary profile on first login.
 ```
+
+#### Improvements
+
+- Fixed UsrClass.dat (and NTUSER.DAT) hive ACL validation being warn-only during migration. ADMU now proactively repairs hive file permissions before first login via `Set-DATFilePermission`.
+- Fixed `$datPath` not being set consistently during home path rename, which could cause hive permission validation to target the wrong profile path.
 
 #### BUG FIXES:
 

--- a/jumpcloud-ADMU/Powershell/Private/RegistryKey/Set-DATFilePermission.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/RegistryKey/Set-DATFilePermission.ps1
@@ -1,0 +1,85 @@
+function Set-DATFilePermission {
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Path,
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Username,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("registry", "ntfs")]
+        [System.String]
+        $Type
+    )
+
+    begin {
+        $aclUser = "$($Env:ComputerName)\$Username"
+        $requiredIdentities = @(
+            "NT AUTHORITY\SYSTEM",
+            "BUILTIN\Administrators",
+            "$aclUser"
+        )
+    }
+
+    process {
+        try {
+            $acl = Get-Acl -Path $Path
+            $isProtected = $acl.AreAccessRulesProtected
+            $modified = $false
+
+            foreach ($identity in $requiredIdentities) {
+                $existingRules = @($acl.Access | Where-Object { $_.IdentityReference -eq $identity })
+                $hasValidAllow = $false
+
+                foreach ($rule in $existingRules) {
+                    if ($rule.AccessControlType -eq 'Deny') {
+                        $acl.RemoveAccessRule($rule) | Out-Null
+                        $modified = $true
+                        Write-ToLog -Message "Set-DATFilePermission: Removed Deny rule for $identity on $Path" -Level Verbose
+                        continue
+                    }
+
+                    $rightsValid = if ($Type -eq 'registry') {
+                        $rule.RegistryRights -contains 'FullControl'
+                    } else {
+                        $rule.FileSystemRights -contains 'FullControl'
+                    }
+
+                    if ($rightsValid) {
+                        $hasValidAllow = $true
+                    } else {
+                        $acl.RemoveAccessRule($rule) | Out-Null
+                        $modified = $true
+                        Write-ToLog -Message "Set-DATFilePermission: Removed insufficient Allow rule for $identity on $Path" -Level Verbose
+                    }
+                }
+
+                if (-not $hasValidAllow) {
+                    if ($Type -eq 'registry') {
+                        $newRule = New-Object System.Security.AccessControl.RegistryAccessRule(
+                            $identity, 'FullControl', 'Allow'
+                        )
+                    } else {
+                        $newRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+                            $identity, 'FullControl', 'Allow'
+                        )
+                    }
+                    $acl.SetAccessRule($newRule)
+                    $modified = $true
+                    Write-ToLog -Message "Set-DATFilePermission: Added Allow FullControl for $identity on $Path" -Level Verbose
+                }
+            }
+
+            if ($modified) {
+                $acl.SetAccessRuleProtection($isProtected, $false)
+                Set-Acl -Path $Path -AclObject $acl
+            }
+        } catch {
+            Write-ToLog -Message "Set-DATFilePermission: Failed to update permissions on $Path : $($_.Exception.Message)" -Level Warning
+            return $false
+        }
+
+        $valid, $null = Test-DATFilePermission -Path $Path -Username $Username -Type $Type
+        return $valid
+    }
+}

--- a/jumpcloud-ADMU/Powershell/Public/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Migration.ps1
@@ -984,20 +984,24 @@ function Start-Migration {
                 }
             }
 
-            # Validate file permissions on registry item
+            # Validate and repair file permissions on loaded registry hives
             Set-HKEYUserMount
-            $validateRegistryPermission, $validateRegistryPermissionResult = Test-DATFilePermission -path "HKEY_USERS:\$($NewUserSID)_admu" -username $jumpcloudUsername -type 'registry'
-            $validateRegistryPermissionClasses, $validateRegistryPermissionClassesResult = Test-DATFilePermission -path "HKEY_USERS:\$($NewUserSID)_Classes_admu" -username $jumpcloudUsername -type 'registry'
-
-            if ($validateRegistryPermission) {
-                Write-ToLog -Message:("The registry permissions for $($NewUserSID)_admu are correct")
-            } else {
-                Write-ToLog -Message:("The registry permissions for $($NewUserSID)_admu are incorrect. Please check permissions SID: $($NewUserSID) ensure Administrators, System, and source user have have Full Control `n$($validateRegistryPermissionResult | Out-String)") -Level Warning
-            }
-            if ($validateRegistryPermissionClasses) {
-                Write-ToLog -Message:("The registry permissions for $($NewUserSID)_Classes_admu are correct ")
-            } else {
-                Write-ToLog -Message:("The registry permissions for $($NewUserSID)_Classes_admu are incorrect. Please check permissions SID: $($NewUserSID) ensure Administrators, System, and source user have have Full Control `n$($validateRegistryPermissionClassesResult | Out-String)") -Level Warning
+            $loadedRegistryHives = @(
+                @{ Path = "HKEY_USERS:\$($NewUserSID)_admu"; Name = "$($NewUserSID)_admu" }
+                @{ Path = "HKEY_USERS:\$($NewUserSID)_Classes_admu"; Name = "$($NewUserSID)_Classes_admu" }
+            )
+            foreach ($loadedHive in $loadedRegistryHives) {
+                $validateRegistryPermission, $validateRegistryPermissionResult = Test-DATFilePermission -path $loadedHive.Path -username $jumpcloudUsername -type 'registry'
+                if (-not $validateRegistryPermission) {
+                    Write-ToLog -Message:("The registry permissions for $($loadedHive.Name) are incorrect. Attempting to repair permissions.") -Level Warning
+                    Set-DATFilePermission -Path $loadedHive.Path -Username $jumpcloudUsername -Type 'registry' | Out-Null
+                    $validateRegistryPermission, $validateRegistryPermissionResult = Test-DATFilePermission -path $loadedHive.Path -username $jumpcloudUsername -type 'registry'
+                }
+                if ($validateRegistryPermission) {
+                    Write-ToLog -Message:("The registry permissions for $($loadedHive.Name) are correct")
+                } else {
+                    Write-ToLog -Message:("The registry permissions for $($loadedHive.Name) are incorrect. Please check permissions SID: $($NewUserSID) ensure Administrators, System, and source user have Full Control `n$($validateRegistryPermissionResult | Out-String)") -Level Warning
+                }
             }
 
             $admuTracker.copyRegistry.pass = $true
@@ -1330,7 +1334,7 @@ function Start-Migration {
                         # Rename the Source User profile path to the new name
                         # -ErrorAction Stop; Rename-Item doesn't throw terminating errors
                         Rename-Item -Path $oldUserProfileImagePath -NewName $JumpCloudUserName -ErrorAction Stop
-                        $datPath = "$($windowsDrive)\Users\$JumpCloudUserName"
+                        $newUserProfileImagePath = "$($windowsDrive)\Users\$JumpCloudUserName"
                     } catch {
                         Write-ToLog -Message:("Unable to rename user profile path to new name - $JumpCloudUserName.")
                         $admuTracker.renameHomeDirectory.fail = $true
@@ -1342,7 +1346,6 @@ function Start-Migration {
             } else {
                 Write-ToLog -Message:("Parameter to Update Home Path was not set.")
                 Write-ToLog -Message:("The $JumpCloudUserName account will point to $oldUserProfileImagePath profile path")
-                $datPath = $oldUserProfileImagePath
 
                 try {
                     Write-ToLog -Message:("Attempting to remove newly created $newUserProfileImagePath")
@@ -1369,6 +1372,7 @@ function Start-Migration {
                 # $admuTracker.renameHomeDirectory.pass = $true
             }
             #endregion renameHomeDirectory
+            $datPath = $newUserProfileImagePath
             Set-ItemProperty -Path ('HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\' + $SelectedUserSID) -Name 'ProfileImagePath' -Value ($newUserProfileImagePath + '.' + "ADMU")
             Set-ItemProperty -Path ('HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\' + $NewUserSID) -Name 'ProfileImagePath' -Value ($newUserProfileImagePath)
             $trackAccountMerge = $true
@@ -1398,21 +1402,23 @@ function Start-Migration {
             #endRegion NTFS Permissions
 
             #region Validate Hive Permissions
-            # Validate if .DAT has correct permissions
-            $validateNTUserDatPermissions, $validateNTUserDatPermissionsResults = Test-DATFilePermission -path "$datPath\NTUSER.DAT" -username $JumpCloudUserName -type 'ntfs'
-
-            $validateUsrClassDatPermissions, $validateUsrClassDatPermissionsResults = Test-DATFilePermission -path "$datPath\AppData\Local\Microsoft\Windows\UsrClass.dat" -username $JumpCloudUserName -type 'ntfs'
             Write-ToProgress -ProgressBar $ProgressBar -Status "validateDatPermissions" -form $isForm -SystemDescription $systemDescription -StatusMap $admuTracker
-
-            if ($validateNTUserDatPermissions ) {
-                Write-ToLog -Message:("NTUSER.DAT Permissions are correct $($datPath)")
-            } else {
-                Write-ToLog -Message:("NTUSER.DAT Permissions are incorrect. Please check permissions on $($datPath)\NTUSER.DAT to ensure Administrators, System, and source user have have Full Control `n$($validateNTUserDatPermissionsResults | Out-String)") -Level Warning
-            }
-            if ($validateUsrClassDatPermissions) {
-                Write-ToLog -Message:("UsrClass.dat Permissions are correct $($datPath)")
-            } else {
-                Write-ToLog -Message:("UsrClass.dat Permissions are incorrect. Please check permissions on $($datPath)\AppData\Local\Microsoft\Windows\UsrClass.dat to ensure Administrators, System, and source user have have Full Control `n$($validateUsrClassDatPermissionsResults | Out-String)") -Level Warning
+            $hiveFiles = @(
+                @{ Path = "$datPath\NTUSER.DAT"; Name = "NTUSER.DAT" }
+                @{ Path = "$datPath\AppData\Local\Microsoft\Windows\UsrClass.dat"; Name = "UsrClass.dat" }
+            )
+            foreach ($hive in $hiveFiles) {
+                $validateHivePermissions, $validateHivePermissionsResults = Test-DATFilePermission -path $hive.Path -username $JumpCloudUserName -type 'ntfs'
+                if (-not $validateHivePermissions) {
+                    Write-ToLog -Message:("$($hive.Name) Permissions are incorrect. Attempting to repair permissions on $($hive.Path)") -Level Warning
+                    Set-DATFilePermission -Path $hive.Path -Username $JumpCloudUserName -Type 'ntfs' | Out-Null
+                    $validateHivePermissions, $validateHivePermissionsResults = Test-DATFilePermission -path $hive.Path -username $JumpCloudUserName -type 'ntfs'
+                }
+                if ($validateHivePermissions) {
+                    Write-ToLog -Message:("$($hive.Name) Permissions are correct $($datPath)")
+                } else {
+                    Write-ToLog -Message:("$($hive.Name) Permissions are incorrect. Please check permissions on $($hive.Path) to ensure Administrators, System, and source user have Full Control `n$($validateHivePermissionsResults | Out-String)") -Level Warning
+                }
             }
             #endRegion Validate Hive Permissions
             ### Active Setup Registry Entry ###

--- a/jumpcloud-ADMU/Powershell/Tests/Private/RegistryKey/Set-DATFilePermission.Acceptance.Tests.ps1
+++ b/jumpcloud-ADMU/Powershell/Tests/Private/RegistryKey/Set-DATFilePermission.Acceptance.Tests.ps1
@@ -1,0 +1,68 @@
+Describe "Set-DATFilePermission Acceptance Tests" -Tag "Acceptance" {
+    BeforeAll {
+        $currentPath = $PSScriptRoot
+        $TargetDirectory = "helperFunctions"
+        $FileName = "Import-AllFunctions.ps1"
+        while ($currentPath -ne $null) {
+            $filePath = Join-Path -Path $currentPath $TargetDirectory
+            if (Test-Path $filePath) {
+                $helpFunctionDir = $filePath
+                break
+            }
+            $currentPath = Split-Path $currentPath -Parent
+        }
+        . "$helpFunctionDir\$FileName"
+        . "$helpFunctionDir\initialize-TestUser.ps1"
+    }
+
+    Context 'Repairs hive permissions when they are broken' {
+        It 'Should repair NTFS permissions on NTUSER.DAT and UsrClass.dat' {
+            $datUser = "ADMU_setdat_" + -join ((65..90) + (97..122) | Get-Random -Count 5 | ForEach-Object { [char]$_ })
+            $password = '$T#st1234'
+            Initialize-TestUser -UserName $datUser -Password $Password
+
+            $filePaths = @(
+                "C:\Users\$datUser\AppData\Local\Microsoft\Windows\UsrClass.dat",
+                "C:\Users\$datUser\NTUSER.DAT"
+            )
+
+            foreach ($filePath in $filePaths) {
+                $fileACL = (Get-Item $filePath -Force).GetAccessControl('Access')
+                $fileACL.SetAccessRuleProtection($true, $true)
+                Set-Acl $filePath -AclObject $fileACL
+
+                $fileACL = Get-Acl $filePath
+                $ruleToRemove = $fileACL.GetAccessRules($true, $true, [System.Security.Principal.NTAccount]) | Where-Object { $_.IdentityReference -match $datUser }
+                if ($ruleToRemove) {
+                    $fileACL.RemoveAccessRule($ruleToRemove) | Out-Null
+                    Set-Acl $filePath -AclObject $fileACL
+                }
+
+                $validBefore, $null = Test-DATFilePermission -Path $filePath -username $datUser -type 'ntfs'
+                $validBefore | Should -Be $false
+
+                $repaired = Set-DATFilePermission -Path $filePath -Username $datUser -Type 'ntfs'
+                $repaired | Should -Be $true
+
+                $validAfter, $null = Test-DATFilePermission -Path $filePath -username $datUser -type 'ntfs'
+                $validAfter | Should -Be $true
+            }
+        }
+
+        It 'Should be idempotent when permissions are already correct' {
+            $datUser = "ADMU_setdat_" + -join ((65..90) + (97..122) | Get-Random -Count 5 | ForEach-Object { [char]$_ })
+            $password = '$T#st1234'
+            Initialize-TestUser -UserName $datUser -Password $Password
+
+            $filePath = "C:\Users\$datUser\NTUSER.DAT"
+            $validBefore, $null = Test-DATFilePermission -Path $filePath -username $datUser -type 'ntfs'
+            $validBefore | Should -Be $true
+
+            $repaired = Set-DATFilePermission -Path $filePath -Username $datUser -Type 'ntfs'
+            $repaired | Should -Be $true
+
+            $validAfter, $null = Test-DATFilePermission -Path $filePath -username $datUser -type 'ntfs'
+            $validAfter | Should -Be $true
+        }
+    }
+}

--- a/jumpcloud-ADMU/Powershell/Tests/Public/Start-Migration.Acceptance.Tests.ps1
+++ b/jumpcloud-ADMU/Powershell/Tests/Public/Start-Migration.Acceptance.Tests.ps1
@@ -302,6 +302,11 @@ Describe "Start-Migration Tests" -Tag "Migration Parameters" {
                 Test-Path "$UserHome\AppData\Local\Microsoft\Windows\UsrClass.dat" | Should -Be $true
                 Test-Path "$UserHome\AppData\Local\Microsoft\Windows\UsrClass_original_$dateMatch.DAT" | Should -Be $true
 
+                $ntUserValid, $null = Test-DATFilePermission -Path "$UserHome\NTUSER.DAT" -Username $userToMigrateTo -Type ntfs
+                $usrClassValid, $null = Test-DATFilePermission -Path "$UserHome\AppData\Local\Microsoft\Windows\UsrClass.dat" -Username $userToMigrateTo -Type ntfs
+                $ntUserValid | Should -Be $true
+                $usrClassValid | Should -Be $true
+
                 # check that the FTA/PTA lists contain the $fileType and $protocol variable from the job
                 $FTAPath = "$($UserHome)\AppData\Local\JumpCloudADMU\fileTypeAssociations.csv"
                 $PTAPath = "$($UserHome)\AppData\Local\JumpCloudADMU\protocolTypeAssociations.csv"


### PR DESCRIPTION
## Issues
* [CUT-5193](https://jumpcloud.atlassian.net/browse/CUT-5193) - Set missing usrClass ntfs permissions

## What does this solve?

If some user is missing their `usrClass.dat` required permissions they'll get a temp profile. It's something we've seen before but not identified a cause in our migration tooling. This change accounts for customers who find themselves in this case by proactively setting the required permissions during migration. 

## Is there anything particularly tricky?

## How should this be tested?

Perform a migration for some user. Before signing into that user's profile:

- Go to C:\Users\some.user\AppData\Local\Microsoft\Windows
- Modify the `usrclass.dat` file's permissions. Most likely you'll have to disable inheritance to do this
- remove `some.user` (or the acl for the user you migrated)
- Switch profiles from administrator to the `some.user` account and attempt to sign in. They user will have a temp profile (which is what is expected)
- Sign off and log back into the administrator's account. 
- Open PowerShell as an admin and run:

```pwsh
function Set-DATFilePermission {
    param (
        [Parameter(Mandatory = $true)]
        [System.String]
        $Path,
        [Parameter(Mandatory = $true)]
        [System.String]
        $Username,
        [Parameter(Mandatory = $true)]
        [ValidateSet("registry", "ntfs")]
        [System.String]
        $Type
    )

    begin {
        $aclUser = "$($Env:ComputerName)\$Username"
        $requiredIdentities = @(
            "NT AUTHORITY\SYSTEM",
            "BUILTIN\Administrators",
            "$aclUser"
        )
    }

    process {
        try {
            $acl = Get-Acl -Path $Path
            $isProtected = $acl.AreAccessRulesProtected
            $modified = $false

            foreach ($identity in $requiredIdentities) {
                $existingRules = @($acl.Access | Where-Object { $_.IdentityReference -eq $identity })
                $hasValidAllow = $false

                foreach ($rule in $existingRules) {
                    if ($rule.AccessControlType -eq 'Deny') {
                        $acl.RemoveAccessRule($rule) | Out-Null
                        $modified = $true
                        # Write-ToLog -Message "Set-DATFilePermission: Removed Deny rule for $identity on $Path" -Level Verbose
                        continue
                    }

                    $rightsValid = if ($Type -eq 'registry') {
                        $rule.RegistryRights -contains 'FullControl'
                    } else {
                        $rule.FileSystemRights -contains 'FullControl'
                    }

                    if ($rightsValid) {
                        $hasValidAllow = $true
                    } else {
                        $acl.RemoveAccessRule($rule) | Out-Null
                        $modified = $true
                        # Write-ToLog -Message "Set-DATFilePermission: Removed insufficient Allow rule for $identity on $Path" -Level Verbose
                    }
                }

                if (-not $hasValidAllow) {
                    if ($Type -eq 'registry') {
                        $newRule = New-Object System.Security.AccessControl.RegistryAccessRule(
                            $identity, 'FullControl', 'Allow'
                        )
                    } else {
                        $newRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
                            $identity, 'FullControl', 'Allow'
                        )
                    }
                    $acl.SetAccessRule($newRule)
                    $modified = $true
                    # Write-ToLog -Message "Set-DATFilePermission: Added Allow FullControl for $identity on $Path" -Level Verbose
                }
            }

            if ($modified) {
                $acl.SetAccessRuleProtection($isProtected, $false)
                Set-Acl -Path $Path -AclObject $acl
            }
        } catch {
            # Write-ToLog -Message "Set-DATFilePermission: Failed to update permissions on $Path : $($_.Exception.Message)" -Level Warning
            return $false
        }

        $valid, $null = Test-DATFilePermission -Path $Path -Username $Username -Type $Type
        return $valid
    }
}
# Function to validate if NTUser.dat has SYSTEM, Administrators, and the specified user as full control
function Test-DATFilePermission {
    param (
        [Parameter(Mandatory = $true)]
        [System.String]
        $path,
        [Parameter(Mandatory = $true)]
        [System.String]
        $username,
        [Parameter(Mandatory = $true)]
        [ValidateSet("registry", "ntfs")]
        [System.String]
        $type

    )
    begin {
        $aclUser = "$($Env:ComputerName)\$username"
        # ACL naming differs on registry/ ntfs file system, set the correct type
        switch ($type) {
            'registry' {
                $FilePermissionType = 'RegistryRights'
            }
            'ntfs' {
                $FilePermissionType = 'FileSystemRights'
            }
        }
        # define empty list
        $permissionsHash = @{}
        # define required list to test
        $requiredAccess = @{
            "NT AUTHORITY\SYSTEM"    = @{
                name = "System"
            };
            "BUILTIN\Administrators" = @{
                name = "Administrators"
            };
            "$($aclUser)"            = @{
                name = "$username"
            }
        }
        # Get the path
        $ACL = Get-Acl $path
    }
    process {
        # Using AccessControlType to check if it's a deny rule instead of allow since, with NTFS permissions, even if a user/admin is denied, there will still be an allow rule for them and not null
        foreach ($requiredRule in $requiredAccess.keys) {
            # foreach ($requiredRule in $systemRule, $administratorsRule, $specifiedUserRule) {
            # write-ToLog "Begin testing: $($requiredRule)"
            $FileACLs = $acl.Access | Where-Object { $_.IdentityReference -eq "$($requiredRule)" }
            # write-ToLog "$($requiredRule) access count: $($FileACLs.Count)"
            foreach ($fileACL in $FileACLs) {
                $rulePermissions = [PSCustomObject]@{
                    access            = $FileACL.AccessControlType
                    permissionType    = $FileACL.$($FilePermissionType)
                    identityReference = $FileACL.IdentityReference
                    ValidPermissions  = $true
                }
                # There will sometimes be multiple FileACLs if an identity is denied access, in which case just break
                if ($FileACL.AccessControlType -contains 'Deny') {
                    $rulePermissions.ValidPermissions = $false
                    $permissionsHash.Add("$($requiredAccess["$($requiredRule)"].name)", $rulePermissions) | Out-Null
                    break
                }
                # if fullControl access is not grated, just break
                if ($FileACL.$($FilePermissionType) -notcontains 'FullControl') {
                    $rulePermissions.ValidPermissions = $false
                    $permissionsHash.Add("$($requiredAccess["$($requiredRule)"].name)", $rulePermissions) | Out-Null
                    break
                }
                # else record the access rule and assume it's valid
                if ("$($requiredAccess["$($requiredRule)"].name)" -notin $permissionsHash.Keys) {
                    $permissionsHash.Add("$($requiredAccess["$($requiredRule)"].name)", $rulePermissions) | Out-Null
                }
            }
            # if the access is not explicitly granted, record the missing value so we can make use of it later
            if (-not $FileACLs) {
                $rulePermissions = [PSCustomObject]@{
                    access            = $null
                    permissionType    = $null
                    identityReference = $requiredRule
                    ValidPermissions  = $false
                }
                if ("$($requiredAccess["$($requiredRule)"].name)" -notin $permissionsHash.Keys) {
                    $permissionsHash.Add("$($requiredAccess["$($requiredRule)"].name)", $rulePermissions) | Out-Null
                }
            }
        }

    }
    end {
        # if the validPermission block contains any 'false' entries, return false + values, else return true + values
        if (($permissionsHash.Values.ValidPermissions -contains $false)) {
            return $false, $permissionsHash.Values
        } else {
            return $true, $permissionsHash.Values
        }
    }
}

```
- with the function to set permissions imported, run:
- `Set-DATFilePermission -Path "C:\Users\some.user\AppData\Local\Microsoft\Windows\usrclass.dat" -Username "some.user" -Type 'ntfs'`
- switch users back into `some.user` 
- the profile should login as normal showing the JumpCloud logo and finish migration

## Screenshots

Some user might encounter this issue if their NTUSER.DAT or usrClass.dat file looked something like this:

<img width="977" height="161" alt="Screenshot 2026-06-04 at 5 20 43 PM" src="https://github.com/user-attachments/assets/be82dff9-0609-4fa7-99d8-6a5e6cd38aac" />

Repairing the permissions with the code above (or what's called when migrating the account)

<img width="992" height="322" alt="Screenshot 2026-06-04 at 5 29 13 PM" src="https://github.com/user-attachments/assets/9d399724-22e3-4ee9-a90b-fdf563a22fc3" />



[CUT-5193]: https://jumpcloud.atlassian.net/browse/CUT-5193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f81633d1a6021e9499211470a044b3e855838cc7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->