### PR TITLE
invoke changes

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -26,7 +26,7 @@ regional date/time formats.
   - Updated in `windowsSystemContext.ps1`, `DeviceQuery.ps1`, `3_ADMU_Invoke.ps1`, and `Invoke-SystemContextAPI.ps1`.
   - Added `Test-JCClientKeyRsaEncoding.ps1` to audit `client.key` encoding and report whether a device is affected (`NeedsPaddingFix`) before rollout.
 - Fixed system context API date header generation on non-English locale Windows systems. The HTTP `Date` header was built by re-parsing a `-UFormat` string with `Get-Date -Date`, which fails when the system culture does not recognize English day/month names (for example, Spanish Windows). ADMU now uses culture-invariant RFC1123 formatting (`[DateTime]::UtcNow.ToString('r')`) for request signing.
-  - Updated in `DeviceQuery.ps1` and `Invoke-SystemContextAPI.ps1`.
+  - Updated in `DeviceQuery.ps1`, `3_ADMU_Invoke.ps1`, and `Invoke-SystemContextAPI.ps1`.
 
 ## 2.13.0
 

--- a/jumpcloud-ADMU-Advanced-Deployment/InvokeFromJCAgent/3_ADMU_Invoke.ps1
+++ b/jumpcloud-ADMU-Advanced-Deployment/InvokeFromJCAgent/3_ADMU_Invoke.ps1
@@ -633,7 +633,7 @@ using System;using System.Collections.Generic;using System.IO;using System.Net;u
                 $rsa = [System.Security.Cryptography.RSA]::Create()
                 $rsa.ImportFromPem($pem)
             }
-            $now = (Get-Date -Date ((Get-Date).ToUniversalTime())-UFormat '+%a, %d %h %Y %H:%M:%S GMT')
+            $now = [DateTime]::UtcNow.ToString('r')
             $signstr = "GET /api/systems/$key HTTP/1.1`ndate: $now"
             $enc = [system.Text.Encoding]::UTF8
             $data = $enc.GetBytes($signstr)


### PR DESCRIPTION
## Issues
* [CUT-5196](https://jumpcloud.atlassian.net/browse/CUT-5196) - Update regional time for System Context Invoke Script

## What does this solve?

Same [issue as this commit](https://github.com/TheJumpCloud/jumpcloud-ADMU/pull/261/changes/c3ac2135318a021845d06583e026b5d83bc9db23) just need to make the change to the invoke script which I forgot when merging 2.13.1

## Is there anything particularly tricky?

## How should this be tested?

## Screenshots

[CUT-5196]: https://jumpcloud.atlassian.net/browse/CUT-5196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line signing header change in the invoke script; same pattern already shipped in other system-context scripts with no broader behavioral change.
> 
> **Overview**
> Backports the **2.13.1** system-context API fix into the JumpCloud Agent invoke path so remote migrations using `systemContextBinding` sign requests correctly on non-English Windows locales.
> 
> In `3_ADMU_Invoke.ps1` (`Get-SystemDescription`), the signed HTTP `Date` header no longer uses `Get-Date` with `-UFormat` and English month/day names. It now uses culture-invariant RFC1123 UTC formatting via `[DateTime]::UtcNow.ToString('r')`, aligned with `DeviceQuery.ps1` and `Invoke-SystemContextAPI.ps1`.
> 
> `ModuleChangelog.md` is updated to list `3_ADMU_Invoke.ps1` among the scripts that received the locale date-header fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c31a7e1f287f5400412d019f29f15319b00db2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->