### PR TITLE
CUT-5203-Validate-DAT-Parent-Permission (#265)

### DIFF
--- a/ModuleChangelog.md
+++ b/ModuleChangelog.md
@@ -1,3 +1,24 @@
+## 2.13.2
+
+Release Date: June 22, 2026
+
+#### RELEASE NOTES
+
+```
+Patch release to address insufficient logging for USRClass.DAT parent permissions
+
+Fix Reverse Migration GUI hang caused by unhandled early validation exceptions
+
+```
+
+#### Improvements
+
+- Added USRClass.dat parent permission validation and logging
+
+#### BUG FIXES:
+
+- Fixed Reverse Migration GUI freezing due to unhandled error/throw
+
 ## 2.13.1
 
 Release Date: June 10, 2026

--- a/jumpcloud-ADMU/JumpCloud.ADMU.psd1
+++ b/jumpcloud-ADMU/JumpCloud.ADMU.psd1
@@ -8,125 +8,125 @@
 
 @{
 
-# Script module or binary module file associated with this manifest.
-RootModule = 'JumpCloud.ADMU.psm1'
+    # Script module or binary module file associated with this manifest.
+    RootModule        = 'JumpCloud.ADMU.psm1'
 
-# Version number of this module.
-ModuleVersion = '2.13.1'
+    # Version number of this module.
+    ModuleVersion     = '2.13.2'
 
-# Supported PSEditions
-# CompatiblePSEditions = @()
+    # Supported PSEditions
+    # CompatiblePSEditions = @()
 
-# ID used to uniquely identify this module
-GUID = '8354fb8a-af52-4db9-9882-a903063751a5'
+    # ID used to uniquely identify this module
+    GUID              = '8354fb8a-af52-4db9-9882-a903063751a5'
 
-# Author of this module
-Author = 'JumpCloud Customer Tools Team'
+    # Author of this module
+    Author            = 'JumpCloud Customer Tools Team'
 
-# Company or vendor of this module
-CompanyName = 'JumpCloud'
+    # Company or vendor of this module
+    CompanyName       = 'JumpCloud'
 
-# Copyright statement for this module
-Copyright = '(c) JumpCloud. All rights reserved.'
+    # Copyright statement for this module
+    Copyright         = '(c) JumpCloud. All rights reserved.'
 
-# Description of the functionality provided by this module
-Description = 'Powershell Module to run JumpCloud Active Directory Migration Utility.'
+    # Description of the functionality provided by this module
+    Description       = 'Powershell Module to run JumpCloud Active Directory Migration Utility.'
 
-# Minimum version of the PowerShell engine required by this module
-# PowerShellVersion = ''
+    # Minimum version of the PowerShell engine required by this module
+    # PowerShellVersion = ''
 
-# Name of the PowerShell host required by this module
-# PowerShellHostName = ''
+    # Name of the PowerShell host required by this module
+    # PowerShellHostName = ''
 
-# Minimum version of the PowerShell host required by this module
-# PowerShellHostVersion = ''
+    # Minimum version of the PowerShell host required by this module
+    # PowerShellHostVersion = ''
 
-# Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# DotNetFrameworkVersion = ''
+    # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # DotNetFrameworkVersion = ''
 
-# Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# ClrVersion = ''
+    # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # ClrVersion = ''
 
-# Processor architecture (None, X86, Amd64) required by this module
-# ProcessorArchitecture = ''
+    # Processor architecture (None, X86, Amd64) required by this module
+    # ProcessorArchitecture = ''
 
-# Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
+    # Modules that must be imported into the global environment prior to importing this module
+    # RequiredModules = @()
 
-# Assemblies that must be loaded prior to importing this module
-# RequiredAssemblies = @()
+    # Assemblies that must be loaded prior to importing this module
+    # RequiredAssemblies = @()
 
-# Script files (.ps1) that are run in the caller's environment prior to importing this module.
-# ScriptsToProcess = @()
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+    # ScriptsToProcess = @()
 
-# Type files (.ps1xml) to be loaded when importing this module
-# TypesToProcess = @()
+    # Type files (.ps1xml) to be loaded when importing this module
+    # TypesToProcess = @()
 
-# Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
+    # Format files (.ps1xml) to be loaded when importing this module
+    # FormatsToProcess = @()
 
-# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-# NestedModules = @()
+    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+    # NestedModules = @()
 
-# Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Start-Migration', 'Start-Reversion'
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport = 'Start-Migration', 'Start-Reversion'
 
-# Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = '*'
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport   = '*'
 
-# Variables to export from this module
-VariablesToExport = '*'
+    # Variables to export from this module
+    VariablesToExport = '*'
 
-# Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = '*'
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport   = '*'
 
-# DSC resources to export from this module
-# DscResourcesToExport = @()
+    # DSC resources to export from this module
+    # DscResourcesToExport = @()
 
-# List of all modules packaged with this module
-# ModuleList = @()
+    # List of all modules packaged with this module
+    # ModuleList = @()
 
-# List of all files packaged with this module
-# FileList = @()
+    # List of all files packaged with this module
+    # FileList = @()
 
-# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
-PrivateData = @{
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData       = @{
 
-    PSData = @{
+        PSData = @{
 
-        # Tags applied to this module. These help with module discovery in online galleries.
-        # Tags = @()
+            # Tags applied to this module. These help with module discovery in online galleries.
+            # Tags = @()
 
-        # A URL to the license for this module.
-        # LicenseUri = ''
+            # A URL to the license for this module.
+            # LicenseUri = ''
 
-        # A URL to the main website for this project.
-        # ProjectUri = ''
+            # A URL to the main website for this project.
+            # ProjectUri = ''
 
-        # A URL to an icon representing this module.
-        # IconUri = ''
+            # A URL to an icon representing this module.
+            # IconUri = ''
 
-        # ReleaseNotes of this module
-        # ReleaseNotes = ''
+            # ReleaseNotes of this module
+            # ReleaseNotes = ''
 
-        # Prerelease string of this module
-        # Prerelease = ''
+            # Prerelease string of this module
+            # Prerelease = ''
 
-        # Flag to indicate whether the module requires explicit user acceptance for install/update/save
-        # RequireLicenseAcceptance = $false
+            # Flag to indicate whether the module requires explicit user acceptance for install/update/save
+            # RequireLicenseAcceptance = $false
 
-        # External dependent modules of this module
-        # ExternalModuleDependencies = @()
+            # External dependent modules of this module
+            # ExternalModuleDependencies = @()
 
-    } # End of PSData hashtable
+        } # End of PSData hashtable
 
-} # End of PrivateData hashtable
+    } # End of PrivateData hashtable
 
-# HelpInfo URI of this module
-# HelpInfoURI = ''
+    # HelpInfo URI of this module
+    # HelpInfoURI = ''
 
-# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-# DefaultCommandPrefix = ''
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    # DefaultCommandPrefix = ''
 
 }
 

--- a/jumpcloud-ADMU/Powershell/Private/DisplayForms/Form.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/DisplayForms/Form.ps1
@@ -33,7 +33,7 @@ function Show-SelectionForm {
 <Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="JumpCloud ADMU 2.13.1"
+        Title="JumpCloud ADMU 2.13.2"
         WindowStyle="SingleBorderWindow"
         ResizeMode="NoResize"
         Background="White" ScrollViewer.VerticalScrollBarVisibility="Visible" ScrollViewer.HorizontalScrollBarVisibility="Visible" Width="1020" Height="590">

--- a/jumpcloud-ADMU/Powershell/Private/DisplayForms/ProgressForm.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/DisplayForms/ProgressForm.ps1
@@ -22,7 +22,7 @@ function New-ProgressForm {
     <Window
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Name="Window" Title="JumpCloud ADMU 2.13.1"
+    Name="Window" Title="JumpCloud ADMU 2.13.2"
     WindowStyle="SingleBorderWindow"
     ResizeMode="NoResize"
     Background="White" Width="720" Height="550  ">

--- a/jumpcloud-ADMU/Powershell/Private/RegistryKey/Test-DATParentPermission.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/RegistryKey/Test-DATParentPermission.ps1
@@ -1,0 +1,50 @@
+function Test-DATParentPermission {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$DirectoryPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$UserSID
+    )
+
+    # SIDs for SYSTEM, Built-in Administrators, and the target user
+    $requiredSIDs = @(
+        'S-1-5-18',     # NT AUTHORITY\SYSTEM
+        'S-1-5-32-544', # BUILTIN\Administrators
+        $UserSID
+    )
+
+    $acl = Get-Acl -Path $DirectoryPath -ErrorAction SilentlyContinue
+    if (-not $acl) {
+        return $false
+    }
+
+    $isValid = $true
+
+    foreach ($sid in $requiredSIDs) {
+        $hasAccess = $false
+
+        foreach ($rule in $acl.Access) {
+            # Translate IdentityReference to a SID string.
+            try {
+                $ruleSid = $rule.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value
+            } catch {
+                # Fallback in case it's already a raw SID string or orphaned
+                $ruleSid = $rule.IdentityReference.Value
+            }
+
+            # Check if the rule applies to our required SID and grants Allow access
+            if ($ruleSid -eq $sid -and $rule.AccessControlType -eq 'Allow') {
+                $hasAccess = $true
+                break
+            }
+        }
+
+        if (-not $hasAccess) {
+            $isValid = $false
+        }
+    }
+
+    return $isValid
+}

--- a/jumpcloud-ADMU/Powershell/Private/RegistryKey/Test-DATParentPermission.ps1
+++ b/jumpcloud-ADMU/Powershell/Private/RegistryKey/Test-DATParentPermission.ps1
@@ -1,5 +1,6 @@
 function Test-DATParentPermission {
     [CmdletBinding()]
+    [OutputType([System.Boolean])]
     param (
         [Parameter(Mandatory = $true)]
         [string]$DirectoryPath,

--- a/jumpcloud-ADMU/Powershell/Public/Start-Migration.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Migration.ps1
@@ -177,7 +177,7 @@ function Start-Migration {
         $AGENT_INSTALLER_URL = "https://cdn02.jumpcloud.com/production/jcagent-msi-signed.msi"
         $AGENT_INSTALLER_PATH = "$windowsDrive\windows\Temp\JCADMU\jcagent-msi-signed.msi"
         $AGENT_CONF_PATH = "$($AGENT_PATH)\Plugins\Contrib\jcagent.conf"
-        $admuVersion = "2.13.1"
+        $admuVersion = "2.13.2"
         $script:JumpCloudUserID = $JumpCloudUserID
         $script:AdminDebug = $AdminDebug
         $isForm = $PSCmdlet.ParameterSetName -eq "form"
@@ -983,7 +983,6 @@ function Start-Migration {
                     }
                 }
             }
-
             # Validate and repair file permissions on loaded registry hives
             Set-HKEYUserMount
             $loadedRegistryHives = @(
@@ -1400,6 +1399,38 @@ function Start-Migration {
                 Write-ToLog -Message "Scheduled task creation failed. Permissions may not be fully applied on first login." -Level Warning
             }
             #endRegion NTFS Permissions
+
+            #region Validate UsrClass.dat Directory Chain
+            Write-ToLog -Message "Validating directory chain permissions up to UsrClass.dat to prevent UPS 1508 error"
+
+            # Path chain up to UsrClass.dat
+            $usrClassChain = @(
+                "$newUserProfileImagePath",
+                "$newUserProfileImagePath\AppData",
+                "$newUserProfileImagePath\AppData\Local",
+                "$newUserProfileImagePath\AppData\Local\Microsoft",
+                "$newUserProfileImagePath\AppData\Local\Microsoft\Windows"
+            )
+
+            $chainValid = $true
+            foreach ($dir in $usrClassChain) {
+                if (Test-Path $dir) {
+                    $dirCheck = Test-DATParentPermission -DirectoryPath $dir -UserSID $NewUserSID
+                    if ($dirCheck) {
+                        Write-ToLog -Message "Validated required permissions (System, Admin, $($NewUserSID)) on: $dir"
+                    } else {
+                        Write-ToLog -Message "Permission validation failed on: $dir. Missing required access." -Level Warning
+                        $chainValid = $false
+                    }
+                } else {
+                    Write-ToLog -Message "Directory not found during validation: $dir" -Level Warning
+                }
+            }
+
+            if (-not $chainValid) {
+                Write-ToLog -Message "CRITICAL WARNING: One or more directories in the UsrClass.dat chain are missing required permissions. This will likely trigger a User Profile Service 1508 error on login." -Level Warning
+            }
+            #endregion Validate UsrClass.dat Directory Chain
 
             #region Validate Hive Permissions
             Write-ToProgress -ProgressBar $ProgressBar -Status "validateDatPermissions" -form $isForm -SystemDescription $systemDescription -StatusMap $admuTracker

--- a/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
@@ -78,18 +78,9 @@ function Start-Reversion {
             WhatIfMode          = $DryRun.IsPresent
             RegistryUpdated     = $false
         }
-        $account = New-Object System.Security.Principal.SecurityIdentifier($UserSID)
-        try {
-            $domainUser = ($account.Translate([System.Security.Principal.NTAccount])).Value
-
-        } catch {
-            throw "UserSID provided could not be translated"
-        }
 
         # Regex pattern to identify .ADMU profile paths
         $admuPathPattern = '\.ADMU$'
-
-        Write-ToLog -Message "Validating user SID: $UserSID" -Level Verbose -Step "Revert-Migration"
 
         # Status message map for reversion steps
         $revertMessageMap = [Ordered]@{
@@ -141,16 +132,28 @@ function Start-Reversion {
         if ((-not $script:ProgressBar) -and ($form)) {
             $script:ProgressBar = New-ProgressForm
         }
-        # VALIDATION: Check if user profile is currently loaded
-        if (Test-UserProfileLoaded -UserSID $UserSID) {
-            $errorMessage = "Cannot revert user profile for SID: $UserSID. The user's profile is currently loaded in memory. Please ensure the user is logged out before attempting reversion."
-            Write-ToLog -Message $errorMessage -Level Error
-            throw $errorMessage
-        }
+
+        $ProgressBar = $script:ProgressBar
     }
 
     process {
         try {
+            $account = New-Object System.Security.Principal.SecurityIdentifier($UserSID)
+            try {
+                $domainUser = ($account.Translate([System.Security.Principal.NTAccount])).Value
+            } catch {
+                throw "UserSID provided could not be translated"
+            }
+
+            Write-ToLog -Message "Validating user SID: $UserSID" -Level Verbose -Step "Revert-Migration"
+
+            # VALIDATION: Check if user profile is currently loaded
+            if (Test-UserProfileLoaded -UserSID $UserSID) {
+                $errorMessage = "Cannot revert user profile for SID: $UserSID. The user's profile is currently loaded in memory. Please ensure the user is logged out before attempting reversion."
+                Write-ToLog -Message $errorMessage -Level Error
+                throw $errorMessage
+            }
+
             #region Validate Registry and Determine Profile Path
             Write-ToLog -Message "Looking up profile information for SID: $UserSID" -Level Info -Step "Revert-Migration"
 

--- a/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
+++ b/jumpcloud-ADMU/Powershell/Public/Start-Reversion.ps1
@@ -139,11 +139,16 @@ function Start-Reversion {
     process {
         try {
             $account = New-Object System.Security.Principal.SecurityIdentifier($UserSID)
+            $userAccountTranslated = $false
             try {
                 $domainUser = ($account.Translate([System.Security.Principal.NTAccount])).Value
+                $userAccountTranslated = $true
             } catch {
-                throw "UserSID provided could not be translated"
+                Write-ToLog -Message "Warning: Could not translate UserSID $UserSID to NTAccount. Using SID string instead." -Level Verbose -Step "Revert-Migration"
+                $domainUser = $UserSID
             }
+
+            $domainUserIcacls = if ($userAccountTranslated) { $domainUser } else { "*$UserSID" }
 
             Write-ToLog -Message "Validating user SID: $UserSID" -Level Verbose -Step "Revert-Migration"
 
@@ -495,7 +500,7 @@ function Start-Reversion {
 
                 $ACLRestoreLogPath = "$(Get-WindowsDrive)\Windows\Temp\jcAdmu_Revert_SetOwner.log"
                 $logPath = "$(Get-WindowsDrive)\Windows\Temp\jcAdmu.log"
-                $icaclsOwnerResult = icacls "$($profileImagePath)" /setowner $domainUser /T /C /Q 2>&1
+                $icaclsOwnerResult = icacls "$($profileImagePath)" /setowner $domainUserIcacls /T /C /Q 2>&1
                 $icaclsOwnerResult | Out-File -FilePath $logPath -Append -Encoding utf8
 
                 Write-ToLog -Message "End of Set Owner Log" -Level Info -Step "Revert-Migration"
@@ -504,7 +509,7 @@ function Start-Reversion {
                 if ($LASTEXITCODE -ne 0) {
                     Write-ToLog -Message "Failed to set ownership of profile directory. Check log at $ACLRestoreLogPath" -Level Warning -Step "Revert-Migration"
                 } else {
-                    Write-ToLog -Message "Successfully set ownership of profile directory to $domainUser" -Level Info -Step "Revert-Migration"
+                    Write-ToLog -Message "Successfully set ownership of profile directory to $domainUserIcacls" -Level Info -Step "Revert-Migration"
                 }
             } else {
                 Write-ToLog -Message "WHAT IF: Would take ownership of profile directory: $profileImagePath" -Level Verbose -Step "Revert-Migration"

--- a/jumpcloud-ADMU/Powershell/Tests/Private/RegistryKey/Test-DATParentPermission.Acceptance.Tests.ps1
+++ b/jumpcloud-ADMU/Powershell/Tests/Private/RegistryKey/Test-DATParentPermission.Acceptance.Tests.ps1
@@ -1,0 +1,102 @@
+Describe "Test-DATParentPermission Acceptance Tests" -Tag "Acceptance" {
+    BeforeAll {
+        $currentPath = $PSScriptRoot
+        $TargetDirectory = "helperFunctions"
+        $FileName = "Import-AllFunctions.ps1"
+        while ($currentPath -ne $null) {
+            $filePath = Join-Path -Path $currentPath $TargetDirectory
+            if (Test-Path $filePath) {
+                $helpFunctionDir = $filePath
+                break
+            }
+            $currentPath = Split-Path $currentPath -Parent
+        }
+        . "$helpFunctionDir\$FileName"
+        . "$helpFunctionDir\initialize-TestUser.ps1"
+    }
+
+    Context 'Evaluates directory permissions for required SIDs' {
+
+        It 'Should return $true when SYSTEM, Administrators, and the target User have Allow access' {
+            # Setup User
+            $datUser = "ADMU_tstprnt_" + -join ((65..90) + (97..122) | Get-Random -Count 5 | ForEach-Object { [char]$_ })
+            $password = '$T#st1234'
+            Initialize-TestUser -UserName $datUser -Password $Password
+
+            # Translate Username to SID for the parameter
+            $ntAccount = New-Object System.Security.Principal.NTAccount($datUser)
+            $userSID = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier]).Value
+
+            # Target the newly created user profile directory
+            $dirPath = "C:\Users\$datUser"
+
+            $isValid = Test-DATParentPermission -DirectoryPath $dirPath -UserSID $userSID
+            $isValid | Should -Be $true
+        }
+
+        It 'Should return $false when the target User is missing Allow access' {
+            $datUser = "ADMU_tstprnt_" + -join ((65..90) + (97..122) | Get-Random -Count 5 | ForEach-Object { [char]$_ })
+            $password = '$T#st1234'
+            Initialize-TestUser -UserName $datUser -Password $Password
+
+            $ntAccount = New-Object System.Security.Principal.NTAccount($datUser)
+            $userSID = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier]).Value
+            $dirPath = "C:\Users\$datUser"
+
+            # Break the ACL: Disable inheritance and set protection
+            $dirACL = Get-Acl $dirPath
+            $dirACL.SetAccessRuleProtection($true, $true)
+            Set-Acl $dirPath -AclObject $dirACL
+
+            # Remove the test user's access rules
+            $dirACL = Get-Acl $dirPath
+            $rulesToRemove = $dirACL.GetAccessRules($true, $true, [System.Security.Principal.NTAccount]) | Where-Object { $_.IdentityReference -match $datUser }
+            if ($rulesToRemove) {
+                foreach ($rule in $rulesToRemove) {
+                    $dirACL.RemoveAccessRule($rule) | Out-Null
+                }
+                Set-Acl $dirPath -AclObject $dirACL
+            }
+
+            $isValid = Test-DATParentPermission -DirectoryPath $dirPath -UserSID $userSID
+            $isValid | Should -Be $false
+        }
+
+        It 'Should return $false when SYSTEM or Administrators are missing Allow access' {
+            $datUser = "ADMU_tstprnt_" + -join ((65..90) + (97..122) | Get-Random -Count 5 | ForEach-Object { [char]$_ })
+            $password = '$T#st1234'
+            Initialize-TestUser -UserName $datUser -Password $Password
+
+            $ntAccount = New-Object System.Security.Principal.NTAccount($datUser)
+            $userSID = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier]).Value
+            $dirPath = "C:\Users\$datUser"
+
+            # Break the ACL: Disable inheritance and set protection
+            $dirACL = Get-Acl $dirPath
+            $dirACL.SetAccessRuleProtection($true, $true)
+            Set-Acl $dirPath -AclObject $dirACL
+
+            # Remove the NT AUTHORITY\SYSTEM access rule (S-1-5-18)
+            $dirACL = Get-Acl $dirPath
+            $rulesToRemove = $dirACL.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier]) | Where-Object { $_.IdentityReference.Value -eq 'S-1-5-18' }
+            if ($rulesToRemove) {
+                foreach ($rule in $rulesToRemove) {
+                    $dirACL.RemoveAccessRule($rule) | Out-Null
+                }
+                Set-Acl $dirPath -AclObject $dirACL
+            }
+
+            $isValid = Test-DATParentPermission -DirectoryPath $dirPath -UserSID $userSID
+            $isValid | Should -Be $false
+        }
+
+        It 'Should return $false if the directory does not exist' {
+            $fakeUserSID = "S-1-5-21-1234567890-1234567890-1234567890-1001"
+            $fakeDirPath = "C:\Fake\Path\That\Definitely\Does\Not\Exist"
+
+            # The function uses SilentlyContinue, so it should return false rather than throwing
+            $isValid = Test-DATParentPermission -DirectoryPath $fakeDirPath -UserSID $fakeUserSID
+            $isValid | Should -Be $false
+        }
+    }
+}

--- a/jumpcloud-ADMU/Powershell/Tests/Public/Start-Reversion.Acceptance.Tests.ps1
+++ b/jumpcloud-ADMU/Powershell/Tests/Public/Start-Reversion.Acceptance.Tests.ps1
@@ -156,7 +156,7 @@ Describe "Start-Reversion Tests" -Tag "Migration Parameters" {
                     TargetProfileImagePath = "C:\Users\$userToMigrateFrom"
                 }
 
-                { Start-Reversion @reversionInput } | Should -Throw "UserSID provided could not be translated"
+                { Start-Reversion @reversionInput } | Should -Throw "*UserSID provided could not be translated*"
             }
             It "Tests that the Reversion fails with an Valid SID and an invalid profilePath" {
 

--- a/jumpcloud-ADMU/Powershell/Tests/Public/Start-Reversion.Acceptance.Tests.ps1
+++ b/jumpcloud-ADMU/Powershell/Tests/Public/Start-Reversion.Acceptance.Tests.ps1
@@ -156,7 +156,7 @@ Describe "Start-Reversion Tests" -Tag "Migration Parameters" {
                     TargetProfileImagePath = "C:\Users\$userToMigrateFrom"
                 }
 
-                { Start-Reversion @reversionInput } | Should -Throw "*UserSID provided could not be translated*"
+                { Start-Reversion @reversionInput } | Should -Throw "*Profile registry path not found for SID*"
             }
             It "Tests that the Reversion fails with an Valid SID and an invalid profilePath" {
 


### PR DESCRIPTION
* 2.13.2

* DAT Parent Test

## Issues
* [CUT-5203](https://jumpcloud.atlassian.net/browse/CUT-5203) - CUT-5203

## What does this solve?
- Added additional logging and validation for USRClass.dat parent directory
- Fixes an issue with Reversion GUI hanging on unhandled error in the begin block

## Is there anything particularly tricky?
N/A
## How should this be tested?
Parent Permission Test

1. Remove one of the permissions such as System or directory in one of the folders like `C:\Users\ReidSullivan\AppData\Local\Microsoft`
2. Start a migration and it should log the issue.
<img width="1080" height="153" alt="image" src="https://github.com/user-attachments/assets/29b170ac-e009-4025-bef2-ed8594cc6092" />

GUI Reversion Test
1. Login to broken user's TEMP profile
2. Run the GUI reverse migration using an admin account. 
3. Validate that it does not freeze and all the action buttons are accessible
<img width="1430" height="553" alt="image" src="https://github.com/user-attachments/assets/19b1e2e1-e499-42b9-9a23-5b78989c5a17" />
[CUT-5203]: https://jumpcloud.atlassian.net/browse/CUT-5203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes run during live profile migration/reversion (ACL checks, icacls ownership, and GUI error handling); impact is mostly diagnostic logging plus a behavioral fix for reversion startup failures.
> 
> **Overview**
> **Release 2.13.2** bumps the module/GUI version and documents two fixes: UsrClass.dat parent permission visibility and reverse-migration GUI responsiveness.
> 
> **Migration** adds `Test-DATParentPermission` and, after NTFS permission work in `Start-Migration`, walks the profile directory chain up to `UsrClass.dat` (profile root through `AppData\Local\Microsoft\Windows`). Each existing folder is checked for **Allow** ACL entries for SYSTEM, Built-in Administrators, and the new user SID; successes and gaps are logged, with a **critical warning** when the chain may cause User Profile Service **1508** on login. Acceptance tests cover the new helper.
> 
> **Reversion** moves SID translation, loaded-profile validation, and related setup from the **`begin`** block into **`process`** inside the main `try`, so early failures (e.g. invalid/unresolvable SID) are handled without freezing the progress form. Untranslatable SIDs no longer abort in `begin`; ownership via `icacls` uses `*$UserSID` when NT account translation fails. The invalid-SID acceptance test now expects a registry lookup failure instead of a translation error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844ee14bb071a12b2c48bc7d40046b7ff826823c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->